### PR TITLE
feat: implement google login using retrofit

### DIFF
--- a/Breaking/app/build.gradle
+++ b/Breaking/app/build.gradle
@@ -2,6 +2,9 @@ plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
 }
+//local.properties 파일 읽기
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
 android {
     compileSdk 32
@@ -14,6 +17,14 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        /*
+            local.properties 에 정의한 값을 네이티브 코드 상에서 사용가능하도록 변수 정의.
+            BuildConfig 클래스에 생성.
+         */
+        buildConfigField "String", "clientId", properties['google_client_id']
+        buildConfigField "String", "clientSecret", properties['google_client_secret']
+        buildConfigField "String", "kakaoApiKey", properties['kakao_api_key']
     }
 
     buildTypes {
@@ -54,6 +65,10 @@ dependencies {
     // retrofit & gson
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+
+    implementation 'com.google.android.gms:play-services-auth:20.2.0' // 구글 로그인 서비스
+
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9") // 코루틴 라이브러리
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/Breaking/app/src/main/AndroidManifest.xml
+++ b/Breaking/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <application
         android:name=".GlobalApplication"
         android:allowBackup="true"
+        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/Breaking/app/src/main/java/com/dope/breaking/GlobalApplication.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/GlobalApplication.kt
@@ -9,6 +9,6 @@ class GlobalApplication : Application() {
         // 다른 초기화 코드들
 
         // Kakao SDK 초기화
-        KakaoSdk.init(this, "014eb771997db4366bd8f4c99aa7c210")
+        KakaoSdk.init(this, BuildConfig.kakaoApiKey)
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/SignInActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/SignInActivity.kt
@@ -1,24 +1,30 @@
 package com.dope.breaking
 
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import com.dope.breaking.databinding.ActivitySignInBinding
-import com.dope.breaking.model.KakaoLogin
-import com.dope.breaking.model.RequestKakaoToken
+import com.dope.breaking.model.*
+import com.dope.breaking.oauth.GoogleLogin
 import com.dope.breaking.retrofit.RetrofitManager
 import com.dope.breaking.retrofit.RetrofitService
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.common.api.ApiException
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
+import kotlinx.coroutines.*
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 
-class SignInActivity: AppCompatActivity() {
+class SignInActivity : AppCompatActivity() {
     // Log Tag
     private val TAG = "SignInActivity.kt"
 
@@ -28,6 +34,11 @@ class SignInActivity: AppCompatActivity() {
     // 매번 null 체크할 필요 없이 바인딩 변수 재 선언
     private val binding get() = mbinding!!
 
+    //구글 로그인 intent 호출 후, 로그인 intent 의 결과를 받기 위해 ActivityResult 객체 선언
+    private lateinit var googleLoginActivityResult: ActivityResultLauncher<Intent>
+
+    private lateinit var googleLogin: GoogleLogin // 구글 로그인에 필요한 기능들이 담겨있는 커스텀 클래스 선언
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -36,6 +47,39 @@ class SignInActivity: AppCompatActivity() {
 
         setContentView(binding.root)
 
+        googleLogin = GoogleLogin(this) // 구글 로그인 커스텀 클래스 객체 초기화
+
+        /*
+        ActivityResult 객체 초기화 및 동시에 콜백 정의.
+        deprecated 된 onActivityResult 콜백 메소드를 대체함.
+        이 콜백의 parameter 는 ActivityResult! 타입으로 이 객체에 resultCode 와 data 가 포함되어 있음.
+         */
+        googleLoginActivityResult =
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+                if (it.resultCode == RESULT_OK) { // 결과가 성공적이라면
+                    try {
+                        val task =
+                            GoogleSignIn.getSignedInAccountFromIntent(it.data) // 구글 로그인 결과 값 가져오기
+                        val account = task.result // 계정정보가 담긴 객체 가져오기
+                        CoroutineScope(Dispatchers.Main).launch {
+                            /*
+                            받아온 계정 데이터를 구글 로그인 요청 메소드의 인자로 넘겨줌으로써 토큰 검증 프로세스 시작
+                            메소드의 결과로 회원가입이 필요한지 필요하지 않은지 boolean 값을 리턴(jwt 토큰의 유무)
+                            true 면 회원가입 필요, false 면 회원가입 필요 x
+                            */
+                            val isNecessary = googleLogin.requestGoogleLogin(account)
+                            println("JWT 토큰 유무 결과: $isNecessary")
+                        }
+                    } catch (e: ApiException) { // ApiException: 구글 로그인 시 발생하는 에러
+                        e.printStackTrace()
+                    }
+                }
+            }
+        // 구글 로그인 버튼 클릭 이벤트
+        binding.btnSignInGoogle.setOnClickListener {
+            startGoogleLoginIntent()
+        }
+
         // 카카오 로그인 버튼 클릭 이벤트 메소드
         binding.btnSignInKakao.setOnClickListener(View.OnClickListener {
             loginKakao()
@@ -43,14 +87,27 @@ class SignInActivity: AppCompatActivity() {
     }
 
     /**
+     * 구글 로그인에 대한 intent 를 호출한다. 로그인 intent 에 대한 결과를 받기 위해 activityResult 사용
+     * @param - None
+     * @return - Unit
+     * @author - Seunggun Sin
+     * @since - 2022-07-07
+     */
+    private fun startGoogleLoginIntent() {
+        val signInIntent: Intent =
+            googleLogin.googleSignInClient.signInIntent // 구글 로그인 intent 객체 생성
+        googleLoginActivityResult.launch(signInIntent) // 결과 값을 받아오는 intent 실행 (startActivityForResult 와 같음)
+    }
+
+    /**
     @description - 카카오톡 어플의 설치 여부와 카카오계정의 유무에 따른 로그인 처리 함수 , 콜백함수에서 로그인에 대한 성공, 실패 결과 로직을 진행한다.
-                   성공할 경우 OAuthToken 타입의 토큰을, 실패할 경우 Throwable 타입의 error 객체를 리턴한다.
+    성공할 경우 OAuthToken 타입의 토큰을, 실패할 경우 Throwable 타입의 error 객체를 리턴한다.
     @param - None
     @return - Unit
     @author - Tae hyun Park
     @since - 2022-07-05
      **/
-    fun loginKakao():Unit {
+    fun loginKakao(): Unit {
         // 카카오계정 로그인 공통 callback
         // 카카오톡으로 로그인 할 수 없어 카카오계정으로 로그인할 경우 사용됨
         val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
@@ -60,7 +117,7 @@ class SignInActivity: AppCompatActivity() {
                 Log.d(TAG, "카카오계정으로 로그인 성공 ${token.accessToken}")
                 UserApiClient.instance.me { user, error ->
                     var nickname = user?.kakaoAccount?.profile?.nickname.toString()
-                    Toast.makeText(this,nickname+"님, 로그인을 환영합니다",Toast.LENGTH_LONG).show()
+                    Toast.makeText(this, nickname + "님, 로그인을 환영합니다", Toast.LENGTH_LONG).show()
                 }
                 // 토큰 검증을 위해 retrofit을 이용하여 back-end 서버에 request
                 ValidationLoginKakao(token.accessToken)
@@ -82,7 +139,10 @@ class SignInActivity: AppCompatActivity() {
                     }
 
                     // 카톡이 설치되어 있지만, 연결된 카카오계정이 없는 경우, 카카오계정으로 로그인 시도
-                    UserApiClient.instance.loginWithKakaoAccount(applicationContext, callback = callback)
+                    UserApiClient.instance.loginWithKakaoAccount(
+                        applicationContext,
+                        callback = callback
+                    )
                 } else if (token != null) {
                     Log.d(TAG, "카카오톡으로 로그인 성공 ${token.accessToken}")
                 }
@@ -94,15 +154,15 @@ class SignInActivity: AppCompatActivity() {
 
     /**
     @description - 토큰 검증 함수로, 로그인 했을 때 받은 accessToken 을 매개변수로 받아온다.
-                   함수 내부에서 builder, baseurl 등 요청을 위한 정보를 담은 retrofit 객체를 정의하고, 서버에게 요청을 하기 위한 인터페이스 service 객체를 받아온다.
-                   service 객체를 통해 요청을 위한 메소드를 구현하고, 반환 값으로는 만들어둔 response body 타입의 call-back 을 구현한다.
-                   그 과정에서 응답이 성공적인지, 실패인지를 판단한다.
+    함수 내부에서 builder, baseurl 등 요청을 위한 정보를 담은 retrofit 객체를 정의하고, 서버에게 요청을 하기 위한 인터페이스 service 객체를 받아온다.
+    service 객체를 통해 요청을 위한 메소드를 구현하고, 반환 값으로는 만들어둔 response body 타입의 call-back 을 구현한다.
+    그 과정에서 응답이 성공적인지, 실패인지를 판단한다.
     @param - token: String
     @return - Unit
     @author - Tae hyun Park
     @since - 2022-07-05 | 2022-07-06
      **/
-    fun ValidationLoginKakao(token: String){
+    fun ValidationLoginKakao(token: String) {
         // 요청 인터페이스 구현을 위한 service 객체 create
         var service = RetrofitManager.retrofit.create(RetrofitService::class.java)
 
@@ -110,21 +170,34 @@ class SignInActivity: AppCompatActivity() {
         var requestTest = RequestKakaoToken(token)
 
         // 토큰 요청과 응답이 이루어지는 call-back 함수
-        service.getKakaoUserInfo(requestTest).enqueue(object : Callback<KakaoLogin> {
+        service.requestKakaoLogin(requestTest).enqueue(object : Callback<ResponseLogin> {
             // 응답이 왔으면
-            override fun onResponse(call: Call<KakaoLogin>, response: Response<KakaoLogin>) {
-                if(response.isSuccessful) { // response의 body가 정상적인지
+            override fun onResponse(call: Call<ResponseLogin>, response: Response<ResponseLogin>) {
+                if (response.isSuccessful) { // response의 body가 정상적인지
                     var data = response.body()    // GsonConverter를 사용해 데이터매핑하여 자동 변환
-                    Log.d(TAG, "successful response body : "+data)
-                }else{
-                    Log.d(TAG, "response error: "+response.errorBody()?.string()!!)
+                    Log.d(TAG, "successful response body : " + data)
+                } else {
+                    Log.d(TAG, "response error: " + response.errorBody()?.string()!!)
                 }
             }
+
             // 응답이 안 오는 경우
-            override fun onFailure(call: Call<KakaoLogin>, t: Throwable) {
+            override fun onFailure(call: Call<ResponseLogin>, t: Throwable) {
                 Log.d("onFailure", "실패$t")
             }
         })
     }
 
+    override fun onStart() {
+        super.onStart()
+        val account = GoogleSignIn.getLastSignedInAccount(this) // 이전에 구글 로그인을 했던 계정 가져오기
+        if (account != null) { // 계정이 있다면
+            Log.d("already", account.email ?: "")
+            Log.d("already2", account.idToken ?: "")
+            Log.d("already3", account.givenName ?: "")
+            Log.d("already4", account.familyName ?: "")
+            Log.d("already5", account.displayName ?: "")
+            Log.d("already5", account.serverAuthCode ?: "")
+        }
+    }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/model/RequestGoogleAccessToken.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/RequestGoogleAccessToken.kt
@@ -1,0 +1,9 @@
+package com.dope.breaking.model
+
+class RequestGoogleAccessToken(
+    val client_id: String,
+    val client_secret: String,
+    val code: String,
+    val grant_type: String = "authorization_code",
+    val redirect_uri: String = ""
+)

--- a/Breaking/app/src/main/java/com/dope/breaking/model/RequestGoogleToken.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/RequestGoogleToken.kt
@@ -1,0 +1,3 @@
+package com.dope.breaking.model
+
+class RequestGoogleToken(val idToken: String, val accessToken: String)

--- a/Breaking/app/src/main/java/com/dope/breaking/model/ResponseGoogleAccessToken.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/ResponseGoogleAccessToken.kt
@@ -1,0 +1,12 @@
+package com.dope.breaking.model
+
+import com.google.gson.annotations.SerializedName
+
+data class ResponseGoogleAccessToken(
+    @SerializedName("access_token") var accessToken: String, // 구글 엑세스 토큰
+    @SerializedName("expires_in") var expiresIn: String, // 엑세스 토큰의 만료까지 남은 시간(초)
+    @SerializedName("id_token") var idToken: String,   // 사용자 ID 토큰
+    @SerializedName("refresh_token") var refreshToken: String, // 새 엑세스 토큰을 얻는 사용되는 토큰
+    @SerializedName("scope") var scope: String, // 엑세스 토큰에서 부여하는 엑세스 범위
+    @SerializedName("token_type") var tokenType: String // 반환된 토큰의 타입 - 항상 Bearer 설정됨
+)

--- a/Breaking/app/src/main/java/com/dope/breaking/model/ResponseLogin.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/ResponseLogin.kt
@@ -2,7 +2,7 @@ package com.dope.breaking.model
 
 import com.google.gson.annotations.SerializedName
 
-data class KakaoLogin (
+data class ResponseLogin (
     @SerializedName("fullname") var fullName:String, // 유저 성 이름
     @SerializedName("username") var userName:String, // 회원번호
     @SerializedName("email") var userEmail:String,   // 유저 이메일

--- a/Breaking/app/src/main/java/com/dope/breaking/oauth/GoogleLogin.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/oauth/GoogleLogin.kt
@@ -1,0 +1,135 @@
+package com.dope.breaking.oauth
+
+import android.content.Context
+import com.dope.breaking.BuildConfig
+import com.dope.breaking.model.RequestGoogleAccessToken
+import com.dope.breaking.model.RequestGoogleToken
+import com.dope.breaking.model.ResponseGoogleAccessToken
+import com.dope.breaking.model.ResponseLogin
+import com.dope.breaking.retrofit.RetrofitManager
+import com.dope.breaking.retrofit.RetrofitService
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import kotlinx.coroutines.*
+import okhttp3.Headers
+import retrofit2.Response
+
+class GoogleLogin(private val context: Context) {
+    private val jwtHeaderKey = "authorization" // JWT 토큰 검증을 위한 헤더 키 값
+
+    // 구글 로그인 시 여러가지 옵션에 대한 객체
+    private val googleSignInOptions: GoogleSignInOptions =
+        GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestIdToken(BuildConfig.clientId) // id 토큰을 요청하는 옵션
+            .requestServerAuthCode(BuildConfig.clientId) // 서버의 인가코드를 요청하는 옵션
+            .requestEmail() // 사용자의 이메일을 요청하는 옵션
+            .build()
+
+    val googleSignInClient: GoogleSignInClient =
+        GoogleSignIn.getClient(this.context, googleSignInOptions) // 구글 로그인을 수행하는 클라이언트 객체
+
+
+    suspend fun requestGoogleLogin(account: GoogleSignInAccount): Boolean {
+        return CoroutineScope(Dispatchers.Main).async(Dispatchers.IO){ // 코루틴 실행
+            /*
+            구글의 엑세스 토큰을 얻기 위해 구글 api 서버에 요청하는 메소드 호출
+            프로젝트에 저장된 클라이언트 id와 비밀번호, 그리고 로그인 시 받은 계정에 존재하는 서버 인가 코드를 인자로 넘긴다.
+            만약 결과가 null 이라면 중단한다.
+            */
+            val accessTokenResponseObject = getGoogleAccessToken(
+                BuildConfig.clientId,
+                BuildConfig.clientSecret,
+                account.serverAuthCode ?: ""
+            ) ?: return@async false
+
+            /*
+            구글로부터 받아온 id 토큰과 access 토큰으로 백엔드 서버에 로그인을 요청하는 메소드 호출
+            */
+            val validationResponse = requestTokenValidation(
+                accessTokenResponseObject.idToken,
+                accessTokenResponseObject.accessToken
+            )
+            return@async hasJwtToken(jwtHeaderKey, validationResponse.headers())
+        }.await()
+    }
+
+    /**
+     * oauth2 구글 api 서버에 엑세스 토큰을 얻기 위한 요청을 보내는 작업 수행
+     * 요청 자체는 동기적으로 실행되며 코루틴을 사용하여 응답의 결과를 async/await 로 전달한다.
+     * suspend 함수
+     * @param clientId(String): 구글 로그인에 대한 우리 프로젝트의 클라이언트 ID
+     * @param clientSecret(String): 구글 로그인에 대한 우리 프로젝트의 클라이언트 보안 비밀번호
+     * @param code(String): 사용자에 의한 구글 로그인 요청으로 받은 서버 인가 코드 값 (serverAuthCode)
+     * @return - ResponseGoogleAccessToken? 객체로 id 토큰과 access 토큰 필드가 담겨 있다.
+     * @author - Seunggun Sin
+     * @since - 2022-07-07
+     */
+    private suspend fun getGoogleAccessToken(
+        clientId: String,
+        clientSecret: String,
+        code: String
+    ): ResponseGoogleAccessToken? {
+        if (code.isEmpty()) { // 서버 인가 코드가 없는 값이라면
+            return null // 요청을 거부하고 null 리턴
+        }
+        /* 코루틴 실행 */
+        return CoroutineScope(Dispatchers.Main).async(Dispatchers.IO) {
+            val googleRetrofitService =
+                RetrofitManager.retrofitGoogle.create(RetrofitService::class.java) // 구글 retrofit 서비스 객체 생성
+
+            // 구글 api 서버에 엑세스 토큰을 동기적으로 요청 → .execute() 메소드
+            val res = googleRetrofitService.requestGoogleAccessToken(
+                RequestGoogleAccessToken(
+                    client_id = clientId,
+                    client_secret = clientSecret,
+                    code = code
+                )
+            ).execute()
+            return@async res.body() // 응답의 body 를 리턴
+        }.await() // async 블럭의 코드가 실행될 때까지 기다리고 끝나면 결과 값 리턴
+    }
+
+    /**
+     * 구글로부터 받아온 id 토큰과 access 토큰을 바탕으로 백엔드 서버에 로그인을 요청한다. (토큰 검증)
+     * @param idToken(String): ID 토큰
+     * @param accessToken(String): Access 토큰
+     * @return - Response<ResponseLogin> 으로 응답 raw 데이터 반환
+     * @author Seunggun Sin
+     * @since - 2022-07-07
+     */
+    private suspend fun requestTokenValidation(
+        idToken: String,
+        accessToken: String
+    ): Response<ResponseLogin> {
+        return CoroutineScope(Dispatchers.Main).async(Dispatchers.IO) {
+            // 백엔드 서버에 대한 retrofit 서비스 객체 생성
+            val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+
+            /*
+            parameter 로 받아온 값을 바탕으로 객체를 요청 body 로 전달 후 백엔드 서버에 로그인 요청
+            동기적으로 요청 → .execute() 메소드
+            */
+            return@async service.requestGoogleLogin(
+                RequestGoogleToken(
+                    idToken,
+                    accessToken
+                )
+            ).execute() // 응답 결과 자체를 리턴
+        }.await() // async 블럭의 코드가 실행될 때까지 기다리고 끝나면 결과 값 리턴
+    }
+
+    /**
+     * JWT 토큰이 있는지 없는지 판단. 헤더의 값이 null 이거나 빈 문자열이면 false 리턴, 값이 존재하면 true 리턴.
+     * @param headerName(String): jwt 토큰을 위한 헤더 key 값으로, "authorization"로 고정
+     * @param headers(Headers): 백엔드 서버로 요청의 결과로 받은 응답의 헤더 객체인 response.headers().
+     * @return 응답의 결과로 토큰이 있는지 없는지에 대한 bool 값 리턴
+     * @author - Seunggun Sin
+     * @since - 2022-07-07
+     */
+    private fun hasJwtToken(headerName: String, headers: Headers): Boolean =
+    // Map 데이터로 인덱스 연산자에 문자열을 넣는 key-value 방식을 사용하여 헤더 map 데이터에 headerName 문자열을 넣었을 때
+        // 나오는 value 의 값이 null 이거나 빈 문자열이라면 false 리턴, 그렇지 않고 정상적인 값이 있으면 true 리턴
+        !(headers[headerName] == null || headers[headerName]!!.isEmpty())
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitManager.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitManager.kt
@@ -10,5 +10,11 @@ class RetrofitManager {
             .baseUrl("https://team-dope.link:8443") // 서버 주소
             .addConverterFactory(GsonConverterFactory.create()) // gson 컨버터
             .build()
+
+        // 구글 api 서버에 대한 retrofit 객체 선언
+        val retrofitGoogle = Retrofit.Builder()
+            .baseUrl("https://oauth2.googleapis.com")
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
@@ -1,7 +1,6 @@
 package com.dope.breaking.retrofit
 
-import com.dope.breaking.model.RequestKakaoToken
-import com.dope.breaking.model.KakaoLogin
+import com.dope.breaking.model.*
 import retrofit2.Call
 import retrofit2.http.*
 
@@ -14,7 +13,23 @@ interface RetrofitService {
     @since - 2022-07-05 | 2022-07-06
      **/
     @POST("oauth/sign-in/kakao")
-    fun getKakaoUserInfo(
-        @Body token : RequestKakaoToken
-    ) : Call<KakaoLogin>
+    fun requestKakaoLogin(@Body token: RequestKakaoToken): Call<ResponseLogin>
+
+    /**
+     * 구글 로그인 토큰 검증 요청 메소드
+     * @request - RequestGoogleToken
+     * @response - ResponseLogin
+     * @author - Seunggun Sin
+     */
+    @POST("oauth/sign-in/google")
+    fun requestGoogleLogin(@Body tokens: RequestGoogleToken): Call<ResponseLogin>
+
+    /**
+     * OAuth2 구글 API 서버로부터 엑세스 토큰 요청 메소드
+     * @request - RequestGoogleAccessToken
+     * @response - ResponseGoogleAccessToken
+     * @author - Seunggun Sin
+     */
+    @POST("token")
+    fun requestGoogleAccessToken(@Body googleRequest: RequestGoogleAccessToken): Call<ResponseGoogleAccessToken>
 }

--- a/Breaking/app/src/main/res/values/strings.xml
+++ b/Breaking/app/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <resources>
     <string name="app_name">Breaking</string>
-    <string name="server_client_id">495554113249-qkdtgd68lie3j2l461kscmi07jcn7af3.apps.googleusercontent.com</string>
     <string name="sign_up_add_profile_text">프로필 추가</string>
     <string name="sign_up_nickname_text">닉네임</string>
     <string name="sign_up_phone_number_text">전화번호</string>


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #9 

## 예상 리뷰 시간
30-min

## 추가 또는 변경사항
- 테스트 프로젝트에서 okhttp3 라이브러리로 구현한 구글 로그인을 더 상위 라이브러리인 retrofit2 이라는 REST API 통신 라이브러리를 사용하여 구글 로그인 및 토큰 검증 구현
  - 구글 로그인 버튼 클릭 시 구글 로그인 팝업창 띄우기  
  - OAuth2 구글 API 서버로 엑세스 토큰 요청 
  - 백엔드 서버로 토큰 검증 요청
  - 재 로그인 시, 이미 로그인한 계정 정보 가져오기
  - retrofit에 사용되는 Request, Response 변환에 사용되는 모델 클래스 생성
  - 코루틴을 사용하여 나름 처리?...
- 구글, 카카오 로그인 API 키와 비밀번호 등 보안 이슈가 있는 데이터들을 `.gitignore` 처리된 `local.properties` 파일에 저장, 그리고 다른 파일에서 우회해서 코드 상으로 가져옴
- 함수, 클래스 등 name refactoring

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
- 구글 로그인 intent 호출
<img src = "https://user-images.githubusercontent.com/54919474/177716683-925fa5bf-5f01-47e9-aafb-46f2411723b5.png" width="40%" height="40%"/>
- 구글 로그인 토큰 검증 프로세스를 다 끝내고 마지막으로 JWT 토큰 검증하는 로직
- <img src = "https://user-images.githubusercontent.com/54919474/177716586-85defe99-8561-4794-8b7b-0ed18dff78c6.png" width="80%" height="80%"/>
- JWT 토큰 검증 결과
<img src = "https://user-images.githubusercontent.com/54919474/177716453-6cbd2b2b-1a30-4e42-bfbd-95db1e85e18c.png" width="60%" height="60%"/>

## 기타
- 보안 이슈
  - 여태껏 개인 프로젝트를 하면서 API를 사용할 때 필요한 key 값과 같은 남에게 공개되지 않아야되는 값을 숨기지 않고 그대로 코드 상에 하드코딩했었는데, 프로젝트 수준에 따라 이제는 숨겨야될 필요가 있을 것 같아서 어떻게 숨겨야할까 고민을 했었는데, 특정 파일에 숨겨야할 값을 저장해두고 .gitignore 파일에 해당 파일을 넣어놓음으로써, 외부에 공개되지 않는다. 
  - 하지만 어떤 파일에 어떻게 저장해야될지에 대해 고민하다 https://wpioneer.tistory.com/197 참고하여 안드로이드에서 해결했다.  
- 테스트 코드
  - 한번 테스트 코드를 작성하기 위해 구글링과 어떤 함수를 테스트할지 그리고 그 함수를 테스트하기 위한 테스트 케이스를 만들어보기 위해 고민을 했었다. 그런데 구현한 함수를 테스트하기 위해서는 구글의 토큰 값을 사용하는데, 토큰 값은 매번 바뀌기 때문에 일관성 있는 테스트 케이스를 사용하기 어렵기 때문에 테스트가 불가능하다고 판단했다. 다른 부서 팀원들에게도 질문해봤지만 명확한 답을 얻지 못했다. 그래도 프론트 팀의 답변에 의하면 클라이언트 쪽에서 테스트 코드를 거의 작성하지 않는다고 한다. 정말 테스트 코드라는 것은 경험과 감이 매우 중요한 것을 깨닫는다...
  - 그리고 안드로이드에서 테스트하기가 참 어렵다고 느껴진 것이 보통 하나의 페이지인 Activity 클래스 안에 대부분 코드를 작성하는데, 그 클래스 안에 메소드를 정의하고 나서 하려고 하면 이것저것 다 얽혀 있어서 뭔가 복잡해지는 상황이 만들어지는 것 같았다. 
  - 그래서 이를 통해 느낀 점은 View 와 관련된 클래스 내부에는 최대한 비즈니스 로직을 피하는게 좋을 것 같다는 생각이 들었다. 기능들을 클래스별로 모듈화해서 호출하는 형식으로 사용하면 괜찮지 않을까 하는 생각이 든다. 
- 동기화 처리
  - okhttp3 라이브러리를 사용해봤을 때, 구글 로그인의 경우 과정이 여러개가 있어서 콜백의 콜백의 콜백 구조로 되어 있어서 클린한 코드처럼 보이지 않았다. 그래서 나름 Clean code로 작성하기 위해 각 프로세스를 함수로 추출하고 싶었다.  
  - 하지만 구글 로그인 프로세스에는 구글 api 서버 요청과 백엔드 서버 요청이라는 네트워크 작업을 하는 두가지 과정이 존재한다. 네트워크 작업은 쓰레드와 같은 비동기로 처리가 되야 하는데, 각 과정을 함수화를 하고 내용에 쓰레드를 사용하게 되면 그 결과 값을 받기가 어려웠다. 
  - 핸들러를 사용하기에는 코드의 위치가 벗어나지기 때문에 사용하기 껄끄러웠고, 쓰레드를 사용하면서 join과 결과를 반환하는 getter를 만듦으로써 동기화해줄 수 있었는데, 클래스를 하나 더 만들고, 뭔가 좀 클린해보이지 않아서 다른 방법을 찾아보다가 코루틴에서 `async()`/`await()`를 사용하여 요청 자체는 동기적으로 하되 전체적인 흐름은 비동기적으로 처리하면서 요청 작업이 끝날 때까지 기다리고 끝나면 결과를 반환하는 형식으로 사용하였다. 
  - 하지만 결과만 나왔지 코드 자체에 대한 이해를 100% 하지는 않았기 때문에 코루틴에 대한 공부가 시급해보인다.  