### PR TITLE
feat: implement sign-up request, store and validate Jwt token

### DIFF
--- a/Breaking/app/src/main/java/com/dope/breaking/SignInActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/SignInActivity.kt
@@ -67,8 +67,15 @@ class SignInActivity : AppCompatActivity() {
                             메소드의 결과로 회원가입이 필요한지 필요하지 않은지 boolean 값을 리턴(jwt 토큰의 유무)
                             true 면 회원가입 필요, false 면 회원가입 필요 x
                             */
-                            val isNecessary = googleLogin.requestGoogleLogin(account)
-                            println("JWT 토큰 유무 결과: $isNecessary")
+                            val isExisting = googleLogin.requestGoogleLogin(account)
+
+                            // Jwt 토큰이 없고, response body 가 정상적인 값이 있다면
+                            if (!isExisting && googleLogin.responseBody != null) {
+                                // 회원가입 페이지로 이동
+                                moveToSignUpPage(googleLogin.responseBody!!)
+                            } else {
+                                // 로그인 처리와 메인 피드로 이동 + 에러 처리 필요
+                            }
                         }
                     } catch (e: ApiException) { // ApiException: 구글 로그인 시 발생하는 에러
                         e.printStackTrace()
@@ -186,6 +193,19 @@ class SignInActivity : AppCompatActivity() {
                 Log.d("onFailure", "실패$t")
             }
         })
+    }
+
+    /**
+     * 회원가입 페이지(Activity) 로 이동하는 함수 with 데이터
+     * @param response(ResponseLogin): 계정 유무 검증에 대한 응답 값
+     * @return - None
+     * @author - Seunggun Sin
+     * @since - 2022-07-09
+     */
+    private fun moveToSignUpPage(response: ResponseLogin) {
+        val intent = Intent(this, SignUpActivity::class.java)
+        intent.putExtra("responseBody", response) // Serializable class 데이터를 집어 넣음
+        startActivity(intent)
     }
 
     override fun onStart() {

--- a/Breaking/app/src/main/java/com/dope/breaking/SignInActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/SignInActivity.kt
@@ -9,6 +9,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import com.dope.breaking.databinding.ActivitySignInBinding
+import com.dope.breaking.exception.ResponseErrorException
 import com.dope.breaking.model.*
 import com.dope.breaking.oauth.GoogleLogin
 import com.dope.breaking.retrofit.RetrofitManager
@@ -68,8 +69,8 @@ class SignInActivity : AppCompatActivity() {
                             true 면 회원가입 필요, false 면 회원가입 필요 x
                             */
                             val isExisting = googleLogin.requestGoogleLogin(account)
-
                             // Jwt 토큰이 없고, response body 가 정상적인 값이 있다면
+
                             if (!isExisting && googleLogin.responseBody != null) {
                                 // 회원가입 페이지로 이동
                                 moveToSignUpPage(googleLogin.responseBody!!)
@@ -79,6 +80,9 @@ class SignInActivity : AppCompatActivity() {
                         }
                     } catch (e: ApiException) { // ApiException: 구글 로그인 시 발생하는 에러
                         e.printStackTrace()
+                    } catch (e: ResponseErrorException) {
+                        e.printStackTrace()
+                        // 응답 에러에 대한 예외 처리하기
                     }
                 }
             }

--- a/Breaking/app/src/main/java/com/dope/breaking/SignUpActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/SignUpActivity.kt
@@ -4,8 +4,14 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.text.InputFilter
 import android.widget.Toast
-import com.dope.breaking.databinding.ActivitySignInBinding
 import com.dope.breaking.databinding.ActivitySignUpBinding
+import com.dope.breaking.exception.MissingJwtTokenException
+import com.dope.breaking.exception.ResponseErrorException
+import com.dope.breaking.model.ResponseLogin
+import com.dope.breaking.signup.Register
+import com.dope.breaking.util.JwtTokenUtil
+import okhttp3.Headers
+import retrofit2.Response
 import java.util.regex.Pattern
 
 class SignUpActivity : AppCompatActivity() {
@@ -15,11 +21,43 @@ class SignUpActivity : AppCompatActivity() {
 
     // 매번 null 체크할 필요 없이 바인딩 변수 재 선언
     private val binding get() = mbinding!!
+    private lateinit var responseBody: ResponseLogin // 로그인 시 생성되는 응답 객체
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         mbinding = ActivitySignUpBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        // 로그인 페이지로부터 받아온 response 객체 할당
+        val intentFromSignIn = intent
+        responseBody = intentFromSignIn.getSerializableExtra("responseBody") as ResponseLogin
+
+        val register = Register() // 커스텀 회원가입 객체 생성
+
+        try {
+            // 회원가입 요청 함수 signature. 아래 형식대로 회원가입 요청 함수 호출.
+//        val responseHeaders = register.startRequestSignUp(inputData =, imageData =, imageName =)
+
+            val responseHeaders: Headers? = null // 테스트용 코드 - 요청 함수에 값 전달하는 기능 완성 시 삭제 바람.
+            val responseHeaders2 = responseHeaders!! // 테스트용 코드 - 요청 함수에 값 전달하는 기능 완성 시 삭제 바람.
+            // 상단 테스트용 코드 두줄을 지우지 않으면 하단 코드들은 NPE 발생
+
+            val tokenUtil = JwtTokenUtil(this) // Jwt Util 객체 생성
+            val token = tokenUtil.getTokenFromResponse(responseHeaders) // 응답으로부터 Jwt 토큰 값 추출
+            if (token != null) {
+                tokenUtil.setToken(token) // SharedPreferences 를 이용하여 Jwt 토큰을 로컬에 저장
+                /*
+                    Jwt 토큰을 이용하여 유저 정보 요청하는 부분 필요
+                */
+            } else {
+                // 존재하지 않는 Jwt 토큰 케이스에 대한 예외 던지기
+                throw MissingJwtTokenException("Jwt 토큰이 존재하지 않습니다.")
+            }
+        } catch (e: ResponseErrorException) {
+            // 예외 처리하기
+        } catch (e: MissingJwtTokenException) {
+            // 예외 처리하기
+        }
 
         // 닉네임 정규표현식 설정
         binding.etNickname.filters = arrayOf(InputFilter { source, _, _, _, _, _ ->
@@ -28,7 +66,7 @@ class SignUpActivity : AppCompatActivity() {
             if (source == "" || ps.matcher(source).matches()) {
                 return@InputFilter source
             }
-            Toast.makeText( this, "한글, 영문, 숫자만 입력 가능합니다.", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, "한글, 영문, 숫자만 입력 가능합니다.", Toast.LENGTH_SHORT).show()
             ""
         }, InputFilter.LengthFilter(10))
 

--- a/Breaking/app/src/main/java/com/dope/breaking/SignUpActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/SignUpActivity.kt
@@ -1,17 +1,24 @@
 package com.dope.breaking
 
+import android.content.Intent
+import android.graphics.Bitmap
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.text.InputFilter
 import android.widget.Toast
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.graphics.drawable.toBitmap
 import com.dope.breaking.databinding.ActivitySignUpBinding
 import com.dope.breaking.exception.MissingJwtTokenException
 import com.dope.breaking.exception.ResponseErrorException
+import com.dope.breaking.model.RequestSignUp
 import com.dope.breaking.model.ResponseLogin
+import com.dope.breaking.model.ResponseJwtUserInfo
 import com.dope.breaking.signup.Register
 import com.dope.breaking.util.JwtTokenUtil
-import okhttp3.Headers
-import retrofit2.Response
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.util.regex.Pattern
 
 class SignUpActivity : AppCompatActivity() {
@@ -22,41 +29,42 @@ class SignUpActivity : AppCompatActivity() {
     // 매번 null 체크할 필요 없이 바인딩 변수 재 선언
     private val binding get() = mbinding!!
     private lateinit var responseBody: ResponseLogin // 로그인 시 생성되는 응답 객체
+    private lateinit var defaultProfile: Bitmap // bitmap 형태의 기본 프로필 이미지
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         mbinding = ActivitySignUpBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        // drawable 에 저장된 기본 xml 을 기본 프로필 이미지 bitmap 으로 생성
+        defaultProfile =
+            AppCompatResources.getDrawable(this, R.drawable.ic_default_profile_image)?.toBitmap()!!
+
         // 로그인 페이지로부터 받아온 response 객체 할당
         val intentFromSignIn = intent
-        responseBody = intentFromSignIn.getSerializableExtra("responseBody") as ResponseLogin
+        if (intentFromSignIn != null) {
+            val data = intentFromSignIn.getSerializableExtra("responseBody")
+            if (data is ResponseLogin)
+                responseBody = data
+        }
 
-        val register = Register() // 커스텀 회원가입 객체 생성
-
-        try {
-            // 회원가입 요청 함수 signature. 아래 형식대로 회원가입 요청 함수 호출.
-//        val responseHeaders = register.startRequestSignUp(inputData =, imageData =, imageName =)
-
-            val responseHeaders: Headers? = null // 테스트용 코드 - 요청 함수에 값 전달하는 기능 완성 시 삭제 바람.
-            val responseHeaders2 = responseHeaders!! // 테스트용 코드 - 요청 함수에 값 전달하는 기능 완성 시 삭제 바람.
-            // 상단 테스트용 코드 두줄을 지우지 않으면 하단 코드들은 NPE 발생
-
-            val tokenUtil = JwtTokenUtil(this) // Jwt Util 객체 생성
-            val token = tokenUtil.getTokenFromResponse(responseHeaders) // 응답으로부터 Jwt 토큰 값 추출
-            if (token != null) {
-                tokenUtil.setToken(token) // SharedPreferences 를 이용하여 Jwt 토큰을 로컬에 저장
-                /*
-                    Jwt 토큰을 이용하여 유저 정보 요청하는 부분 필요
-                */
-            } else {
-                // 존재하지 않는 Jwt 토큰 케이스에 대한 예외 던지기
-                throw MissingJwtTokenException("Jwt 토큰이 존재하지 않습니다.")
-            }
-        } catch (e: ResponseErrorException) {
-            // 예외 처리하기
-        } catch (e: MissingJwtTokenException) {
-            // 예외 처리하기
+        CoroutineScope(Dispatchers.Main).launch {
+            // 테스트 input 객체 - 기능 구현 완료 시 삭제 바람
+            val testInputData = RequestSignUp(
+                responseBody.userName,
+                "test_nickname",
+                "01012345678",
+                responseBody.userEmail,
+                "홍길동",
+                "테스트 회원가입",
+                true
+            )
+            // 회원가입 요청 시작, 회원가입 버튼 클릭하고 검증 완료 후 input 데이터와 함께 호출
+            processSignUp(
+                inputData = testInputData,
+                imageData = defaultProfile,
+                imageName = "default.png"
+            )
         }
 
         // 닉네임 정규표현식 설정
@@ -70,5 +78,65 @@ class SignUpActivity : AppCompatActivity() {
             ""
         }, InputFilter.LengthFilter(10))
 
+    }
+
+    /**
+     * 모듈들을 불러서 회원가입 요청을 하는 프로세스 함수
+     * @param inputData(RequestSignUp): 필드 데이터 객체
+     * @param imageData(Bitmap): bitmap 형태의 프로필 이미지 데이터
+     * @param imageName(String): 이미지 데이터의 파일 이름
+     * @return None
+     * @author Seunggun Sin
+     * @since 2022-07-11
+     */
+    private suspend fun processSignUp(
+        inputData: RequestSignUp,
+        imageData: Bitmap,
+        imageName: String
+    ) {
+        try {
+            val register = Register() // 커스텀 회원가입 객체 생성
+            // 회원가입 요청 함수 signature. 아래 형식대로 회원가입 요청 함수 호출.
+            // 현재 input 은 테스트용이므로 실제 input 값으로 대체 바람
+            val responseHeaders = register.startRequestSignUp(
+                inputData = inputData,
+                imageData = imageData,
+                imageName = imageName
+            )
+
+            val tokenUtil = JwtTokenUtil(applicationContext) // Jwt Util 객체 생성
+            val token = tokenUtil.getTokenFromResponse(responseHeaders) // 응답으로부터 Jwt 토큰 값 추출
+
+            if (token != null) { // 토큰이 존재하면
+                tokenUtil.setToken(token) // SharedPreferences 를 이용하여 Jwt 토큰을 로컬에 저장
+
+                //회원가입 응답으로 받아온 토큰 값을 토대로 유저의 기본 정보 가져오는 요청
+                val userInfo = tokenUtil.validateJwtToken("Bearer $token")
+                moveToMainPage(userInfo) // 가져온 유저 정보 값을 가지고 메인 페이지로 이동하기
+            } else {
+                // 존재하지 않는 Jwt 토큰 케이스에 대한 예외 던지기
+                throw MissingJwtTokenException("Jwt 토큰이 존재하지 않습니다.")
+            }
+        } catch (e: ResponseErrorException) {
+            e.printStackTrace()
+            // 응답 에러에 대한 예외 처리하기
+        } catch (e: MissingJwtTokenException) {
+            // 토큰 값이 존재하지 않을 때에 대한 예외 처리하기
+        }
+    }
+
+    /**
+     * 유저 정보를 갖고 메인 피드 페이지로 이동하는 메소드 (임시로 MainActivity 로 설정)
+     * @param userInfo(ResponseJwtUserInfo): Jwt 토큰 확인을 통해 받은 Response DTO 객체
+     * @return None
+     * @author Seunggun Sin
+     * @since 2022-07-11
+     */
+    private fun moveToMainPage(userInfo: ResponseJwtUserInfo) {
+        val intent = Intent(this, MainActivity::class.java)
+        intent.putExtra("userInfo", userInfo)
+        intent.flags =
+            Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        startActivity(intent)
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/exception/MissingJwtTokenException.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/exception/MissingJwtTokenException.kt
@@ -1,0 +1,6 @@
+package com.dope.breaking.exception
+
+/**
+ * 특정 위치에서 Jwt 토큰을 가져올 때, 토큰 값이 없을 때 발생하는 예외 클래스
+ */
+class MissingJwtTokenException(message: String) : Exception(message)

--- a/Breaking/app/src/main/java/com/dope/breaking/exception/ResponseErrorException.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/exception/ResponseErrorException.kt
@@ -1,0 +1,6 @@
+package com.dope.breaking.exception
+
+/**
+ * Http 통신에서 status code 가 2xx이 아닌 경우에 발생하는 예외 클래스
+ */
+class ResponseErrorException(message: String) : Exception(message)

--- a/Breaking/app/src/main/java/com/dope/breaking/model/RequestSignUp.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/RequestSignUp.kt
@@ -1,0 +1,50 @@
+package com.dope.breaking.model
+
+import org.json.JSONObject
+
+/**
+ * 회원가입 요청을 보낼 때 넣는 데이터 클래스
+ */
+data class RequestSignUp(
+    val username: String,
+    val nickname: String,
+    val phoneNumber: String,
+    val email: String,
+    val realName: String,
+    val statusMsg: String,
+    private val _role: Boolean // 신분 필드: 일반인=true, 언론인=false
+) {
+    val role: String = if (_role) "USER" else "PRESS" // Boolean 에서 문자열로 변환
+
+    /**
+     * 모든 필드 값들을 json 데이터로 변환해주는 메소드
+     * @param - None
+     * @return - JSONObject: 모든 필드들을 json 으로 변환한 객체 반환
+     * @author - Seunggun Sin
+     * @since - 2022-07-08
+     */
+    fun convertFieldsToJson(): JSONObject {
+        val jsonObject = JSONObject()
+        jsonObject.put("username", username)
+        jsonObject.put("nickname", nickname)
+        jsonObject.put("phoneNumber", phoneNumber)
+        jsonObject.put("email", email)
+        jsonObject.put("realName", realName)
+        jsonObject.put("statusMsg", statusMsg)
+        jsonObject.put("role", role)
+        return jsonObject
+    }
+
+    /**
+     * json 형태의 데이터를 json string 형태로 변환해주는 메소드
+     * @param - None
+     * @return - String: 필드 값들을 json 형태로 변환 후 뒤, 문자열로 변환한 값 반환
+     * @author - Seunggun Sin
+     * @since - 2022-07-08
+     */
+    fun convertJsonToString(): String {
+        val json = convertFieldsToJson() // json 으로 변환
+        return json.toString() // json 을 문자열로 변환
+    }
+
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/model/ResponseJwtUserInfo.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/ResponseJwtUserInfo.kt
@@ -1,0 +1,10 @@
+package com.dope.breaking.model
+
+import com.google.gson.annotations.SerializedName
+import java.io.Serializable
+
+data class ResponseJwtUserInfo(
+    @SerializedName("userId") val userId: Int, // 유저 고유 번호
+    @SerializedName("profileImgURL") val profileImgUrl: String, // 프로필 이미지 url
+    @SerializedName("nickname") val nickname: String // 유저 닉네임
+) : Serializable

--- a/Breaking/app/src/main/java/com/dope/breaking/model/ResponseLogin.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/ResponseLogin.kt
@@ -1,10 +1,11 @@
 package com.dope.breaking.model
 
 import com.google.gson.annotations.SerializedName
+import java.io.Serializable
 
-data class ResponseLogin (
-    @SerializedName("fullname") var fullName:String, // 유저 성 이름
-    @SerializedName("username") var userName:String, // 회원번호
-    @SerializedName("email") var userEmail:String,   // 유저 이메일
-    @SerializedName("profileImgURL") var profileImgUrl:String // 프로필 이미지 Url
-)
+data class ResponseLogin(
+    @SerializedName("fullname") var fullName: String, // 유저 성 이름
+    @SerializedName("username") var userName: String, // 회원번호
+    @SerializedName("email") var userEmail: String,   // 유저 이메일
+    @SerializedName("profileImgURL") var profileImgUrl: String // 프로필 이미지 Url
+) : Serializable

--- a/Breaking/app/src/main/java/com/dope/breaking/oauth/GoogleLogin.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/oauth/GoogleLogin.kt
@@ -2,6 +2,7 @@ package com.dope.breaking.oauth
 
 import android.content.Context
 import com.dope.breaking.BuildConfig
+import com.dope.breaking.exception.ResponseErrorException
 import com.dope.breaking.model.RequestGoogleAccessToken
 import com.dope.breaking.model.RequestGoogleToken
 import com.dope.breaking.model.ResponseGoogleAccessToken
@@ -12,6 +13,9 @@ import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import okhttp3.Headers
 import retrofit2.Response
 
@@ -33,10 +37,12 @@ class GoogleLogin(private val context: Context) {
     /**
      * OAuth2 구글 로그인 프로세스 과정에 대한 함수 (엑세스 토큰 요청 → 토큰 검증 요청 → Jwt 토큰 유무 체크)
      * @param account(GoogleSignInAccount): 구글 로그인 시 얻는 계정 정보 객체
-     * @return - Boolean: 구글 로그인 과정을 통해 사용자가 회원가입이 필요한지 필요하지 않은지에 대한 bool 값 리턴(필요하면 false 리턴)
+     * @return Boolean: 구글 로그인 과정을 통해 사용자가 회원가입이 필요한지 필요하지 않은지에 대한 bool 값 리턴(필요하면 false 리턴)
+     * @throws ResponseErrorException: 정상 응답 (2xx) 이외의 응답이 왔을 때 exception 발생
      * @author Seunggun Sin
-     * @since 2022-07-07 | 2022-07-10
+     * @since 2022-07-07 | 2022-07-11
      */
+    @Throws(ResponseErrorException::class)
     suspend fun requestGoogleLogin(account: GoogleSignInAccount): Boolean {
         /*
         구글의 엑세스 토큰을 얻기 위해 구글 api 서버에 요청하는 메소드 호출
@@ -56,13 +62,19 @@ class GoogleLogin(private val context: Context) {
             accessTokenResponseObject.idToken,
             accessTokenResponseObject.accessToken
         )
-
         if (validationResponse.errorBody() == null) {
             responseBody = validationResponse.body()!!
         }
-
-        // 토큰이 있으면 true, 없으면 false 리턴
-        return hasJwtToken(jwtHeaderKey, validationResponse.headers())
+        if (validationResponse.code() in 200..299) {
+            // 토큰이 있으면 true, 없으면 false 리턴
+            return hasJwtToken(jwtHeaderKey, validationResponse.headers())
+        } else {
+            throw ResponseErrorException(
+                "요청에 실패하였습니다. code: ${validationResponse.code()}\nerror: ${
+                    validationResponse.errorBody()?.string()
+                }"
+            )
+        }
     }
 
     /**
@@ -72,9 +84,9 @@ class GoogleLogin(private val context: Context) {
      * @param clientId(String): 구글 로그인에 대한 우리 프로젝트의 클라이언트 ID
      * @param clientSecret(String): 구글 로그인에 대한 우리 프로젝트의 클라이언트 보안 비밀번호
      * @param code(String): 사용자에 의한 구글 로그인 요청으로 받은 서버 인가 코드 값 (serverAuthCode)
-     * @return - ResponseGoogleAccessToken? 객체로 id 토큰과 access 토큰 필드가 담겨 있다.
-     * @author - Seunggun Sin
-     * @since - 2022-07-07 | 2022-07-10
+     * @return ResponseGoogleAccessToken? 객체로 id 토큰과 access 토큰 필드가 담겨 있다.
+     * @author Seunggun Sin
+     * @since 2022-07-07 | 2022-07-10
      */
     private suspend fun getGoogleAccessToken(
         clientId: String,
@@ -102,28 +114,31 @@ class GoogleLogin(private val context: Context) {
      * 구글로부터 받아온 id 토큰과 access 토큰을 바탕으로 백엔드 서버에 로그인을 요청한다. (토큰 검증)
      * retrofit 요청 메소드의 리턴을 Response 로 설정하여 값을 바로 받아오도록 수정
      * suspend 함수
+     * ※ 응답의 형태가 여러가지인 경우 Response 방식이 아닌 Call 방식 사용하여 코드에 따른 처리하기
      * @param idToken(String): ID 토큰
      * @param accessToken(String): Access 토큰
-     * @return - Response<ResponseLogin> 으로 응답 raw 데이터 반환
+     * @return Response<ResponseLogin> 으로 응답 raw 데이터 반환
      * @author Seunggun Sin
-     * @since - 2022-07-07 | 2022-07-10
+     * @since 2022-07-07 | 2022-07-11
      */
     private suspend fun requestTokenValidation(
         idToken: String,
         accessToken: String
     ): Response<ResponseLogin> {
-        // 백엔드 서버에 대한 retrofit 서비스 객체 생성
-        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
-        /*
-        parameter 로 받아온 값을 바탕으로 객체를 요청 body 로 전달 후 백엔드 서버에 로그인 요청
-        동기적으로 요청 → .execute() 메소드
-        */
-        return service.requestGoogleLogin(
-            RequestGoogleToken(
-                idToken,
-                accessToken
-            )
-        ) // 요청에 대한 응답 객체 리턴
+        return CoroutineScope(Dispatchers.Main).async(Dispatchers.IO) {
+            // 백엔드 서버에 대한 retrofit 서비스 객체 생성
+            val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+            /*
+            parameter 로 받아온 값을 바탕으로 객체를 요청 body 로 전달 후 백엔드 서버에 로그인 요청
+            동기적으로 요청 → .execute() 메소드
+            */
+            return@async service.requestGoogleLogin(
+                RequestGoogleToken(
+                    idToken,
+                    accessToken
+                )
+            ).execute() // 응답 결과 자체를 리턴
+        }.await() // async 블럭의 코드가 실행될 때까지 기다리고 끝나면 결과 값 리턴
     }
 
     /**
@@ -131,11 +146,11 @@ class GoogleLogin(private val context: Context) {
      * @param headerName(String): jwt 토큰을 위한 헤더 key 값으로, "authorization"로 고정
      * @param headers(Headers): 백엔드 서버로 요청의 결과로 받은 응답의 헤더 객체인 response.headers().
      * @return 응답의 결과로 토큰이 있는지 없는지에 대한 bool 값 리턴
-     * @author - Seunggun Sin
-     * @since - 2022-07-07
+     * @author Seunggun Sin
+     * @since 2022-07-07
      */
     private fun hasJwtToken(headerName: String, headers: Headers): Boolean =
-    // Map 데이터로 인덱스 연산자에 문자열을 넣는 key-value 방식을 사용하여 헤더 map 데이터에 headerName 문자열을 넣었을 때
+        // Map 데이터로 인덱스 연산자에 문자열을 넣는 key-value 방식을 사용하여 헤더 map 데이터에 headerName 문자열을 넣었을 때
         // 나오는 value 의 값이 null 이거나 빈 문자열이라면 false 리턴, 그렇지 않고 정상적인 값이 있으면 true 리턴
         !(headers[headerName] == null || headers[headerName]!!.isEmpty())
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/oauth/GoogleLogin.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/oauth/GoogleLogin.kt
@@ -12,12 +12,12 @@ import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
-import kotlinx.coroutines.*
 import okhttp3.Headers
 import retrofit2.Response
 
 class GoogleLogin(private val context: Context) {
     private val jwtHeaderKey = "authorization" // JWT 토큰 검증을 위한 헤더 키 값
+    var responseBody: ResponseLogin? = null // 구글 로그인 프로세스 가운데 얻는 response body 값
 
     // 구글 로그인 시 여러가지 옵션에 대한 객체
     private val googleSignInOptions: GoogleSignInOptions =
@@ -30,41 +30,51 @@ class GoogleLogin(private val context: Context) {
     val googleSignInClient: GoogleSignInClient =
         GoogleSignIn.getClient(this.context, googleSignInOptions) // 구글 로그인을 수행하는 클라이언트 객체
 
-
+    /**
+     * OAuth2 구글 로그인 프로세스 과정에 대한 함수 (엑세스 토큰 요청 → 토큰 검증 요청 → Jwt 토큰 유무 체크)
+     * @param account(GoogleSignInAccount): 구글 로그인 시 얻는 계정 정보 객체
+     * @return - Boolean: 구글 로그인 과정을 통해 사용자가 회원가입이 필요한지 필요하지 않은지에 대한 bool 값 리턴(필요하면 false 리턴)
+     * @author Seunggun Sin
+     * @since 2022-07-07 | 2022-07-10
+     */
     suspend fun requestGoogleLogin(account: GoogleSignInAccount): Boolean {
-        return CoroutineScope(Dispatchers.Main).async(Dispatchers.IO){ // 코루틴 실행
-            /*
-            구글의 엑세스 토큰을 얻기 위해 구글 api 서버에 요청하는 메소드 호출
-            프로젝트에 저장된 클라이언트 id와 비밀번호, 그리고 로그인 시 받은 계정에 존재하는 서버 인가 코드를 인자로 넘긴다.
-            만약 결과가 null 이라면 중단한다.
-            */
-            val accessTokenResponseObject = getGoogleAccessToken(
-                BuildConfig.clientId,
-                BuildConfig.clientSecret,
-                account.serverAuthCode ?: ""
-            ) ?: return@async false
+        /*
+        구글의 엑세스 토큰을 얻기 위해 구글 api 서버에 요청하는 메소드 호출
+        프로젝트에 저장된 클라이언트 id와 비밀번호, 그리고 로그인 시 받은 계정에 존재하는 서버 인가 코드를 인자로 넘긴다.
+        만약 결과가 null 이라면 중단한다.
+        */
+        val accessTokenResponseObject = getGoogleAccessToken(
+            BuildConfig.clientId,
+            BuildConfig.clientSecret,
+            account.serverAuthCode ?: ""
+        ) ?: return false
 
-            /*
-            구글로부터 받아온 id 토큰과 access 토큰으로 백엔드 서버에 로그인을 요청하는 메소드 호출
-            */
-            val validationResponse = requestTokenValidation(
-                accessTokenResponseObject.idToken,
-                accessTokenResponseObject.accessToken
-            )
-            return@async hasJwtToken(jwtHeaderKey, validationResponse.headers())
-        }.await()
+        /*
+        구글로부터 받아온 id 토큰과 access 토큰으로 백엔드 서버에 로그인을 요청하는 메소드 호출
+        */
+        val validationResponse = requestTokenValidation(
+            accessTokenResponseObject.idToken,
+            accessTokenResponseObject.accessToken
+        )
+
+        if (validationResponse.errorBody() == null) {
+            responseBody = validationResponse.body()!!
+        }
+
+        // 토큰이 있으면 true, 없으면 false 리턴
+        return hasJwtToken(jwtHeaderKey, validationResponse.headers())
     }
 
     /**
-     * oauth2 구글 api 서버에 엑세스 토큰을 얻기 위한 요청을 보내는 작업 수행
-     * 요청 자체는 동기적으로 실행되며 코루틴을 사용하여 응답의 결과를 async/await 로 전달한다.
+     * OAuth2 구글 api 서버에 엑세스 토큰을 얻기 위한 요청을 보내는 작업 수행
+     * retrofit 요청 메소드의 리턴을 Response 로 설정하여 값을 바로 받아오도록 수정
      * suspend 함수
      * @param clientId(String): 구글 로그인에 대한 우리 프로젝트의 클라이언트 ID
      * @param clientSecret(String): 구글 로그인에 대한 우리 프로젝트의 클라이언트 보안 비밀번호
      * @param code(String): 사용자에 의한 구글 로그인 요청으로 받은 서버 인가 코드 값 (serverAuthCode)
      * @return - ResponseGoogleAccessToken? 객체로 id 토큰과 access 토큰 필드가 담겨 있다.
      * @author - Seunggun Sin
-     * @since - 2022-07-07
+     * @since - 2022-07-07 | 2022-07-10
      */
     private suspend fun getGoogleAccessToken(
         clientId: String,
@@ -74,50 +84,46 @@ class GoogleLogin(private val context: Context) {
         if (code.isEmpty()) { // 서버 인가 코드가 없는 값이라면
             return null // 요청을 거부하고 null 리턴
         }
-        /* 코루틴 실행 */
-        return CoroutineScope(Dispatchers.Main).async(Dispatchers.IO) {
-            val googleRetrofitService =
-                RetrofitManager.retrofitGoogle.create(RetrofitService::class.java) // 구글 retrofit 서비스 객체 생성
+        val googleRetrofitService =
+            RetrofitManager.retrofitGoogle.create(RetrofitService::class.java) // 구글 retrofit 서비스 객체 생성
 
-            // 구글 api 서버에 엑세스 토큰을 동기적으로 요청 → .execute() 메소드
-            val res = googleRetrofitService.requestGoogleAccessToken(
-                RequestGoogleAccessToken(
-                    client_id = clientId,
-                    client_secret = clientSecret,
-                    code = code
-                )
-            ).execute()
-            return@async res.body() // 응답의 body 를 리턴
-        }.await() // async 블럭의 코드가 실행될 때까지 기다리고 끝나면 결과 값 리턴
+        // 구글 api 서버에 엑세스 토큰을 동기적으로 요청 → .execute() 메소드
+        val res = googleRetrofitService.requestGoogleAccessToken(
+            RequestGoogleAccessToken(
+                client_id = clientId,
+                client_secret = clientSecret,
+                code = code
+            )
+        )
+        return res.body() // 응답의 body 를 리턴
     }
 
     /**
      * 구글로부터 받아온 id 토큰과 access 토큰을 바탕으로 백엔드 서버에 로그인을 요청한다. (토큰 검증)
+     * retrofit 요청 메소드의 리턴을 Response 로 설정하여 값을 바로 받아오도록 수정
+     * suspend 함수
      * @param idToken(String): ID 토큰
      * @param accessToken(String): Access 토큰
      * @return - Response<ResponseLogin> 으로 응답 raw 데이터 반환
      * @author Seunggun Sin
-     * @since - 2022-07-07
+     * @since - 2022-07-07 | 2022-07-10
      */
     private suspend fun requestTokenValidation(
         idToken: String,
         accessToken: String
     ): Response<ResponseLogin> {
-        return CoroutineScope(Dispatchers.Main).async(Dispatchers.IO) {
-            // 백엔드 서버에 대한 retrofit 서비스 객체 생성
-            val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
-
-            /*
-            parameter 로 받아온 값을 바탕으로 객체를 요청 body 로 전달 후 백엔드 서버에 로그인 요청
-            동기적으로 요청 → .execute() 메소드
-            */
-            return@async service.requestGoogleLogin(
-                RequestGoogleToken(
-                    idToken,
-                    accessToken
-                )
-            ).execute() // 응답 결과 자체를 리턴
-        }.await() // async 블럭의 코드가 실행될 때까지 기다리고 끝나면 결과 값 리턴
+        // 백엔드 서버에 대한 retrofit 서비스 객체 생성
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+        /*
+        parameter 로 받아온 값을 바탕으로 객체를 요청 body 로 전달 후 백엔드 서버에 로그인 요청
+        동기적으로 요청 → .execute() 메소드
+        */
+        return service.requestGoogleLogin(
+            RequestGoogleToken(
+                idToken,
+                accessToken
+            )
+        ) // 요청에 대한 응답 객체 리턴
     }
 
     /**

--- a/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
@@ -1,7 +1,10 @@
 package com.dope.breaking.retrofit
 
 import com.dope.breaking.model.*
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.*
 
 interface RetrofitService {
@@ -22,7 +25,33 @@ interface RetrofitService {
      * @author - Seunggun Sin
      */
     @POST("oauth/sign-in/google")
-    fun requestGoogleLogin(@Body tokens: RequestGoogleToken): Call<ResponseLogin>
+    suspend fun requestGoogleLogin(@Body tokens: RequestGoogleToken): Response<ResponseLogin>
+
+    /**
+     * 최종 회원가입 요청 메소드 - Multipart 요청
+     * @param image(MultipartBody.Part): 이미지가 담긴 multi form 요청 body (key=profileImg)
+     * @param data(RequestBody): 나머지 텍스트 필드 값이 담긴 요청 body (key=signUpRequest)
+     * @response - String: 응답 body 자체는 중요 x, Jwt 토큰을 위한 헤더 값만 필요
+     * @author - Seunggun Sin
+     */
+    @Multipart
+    @POST("oauth2/sign-up")
+    fun requestSignUp(
+        @Part image: MultipartBody.Part,
+        @Part("signUpRequest") data: RequestBody
+    ): Response<String>
+
+    /**
+     * 앱을 재시작하고 자동 로그인 시, Jwt 토큰 만료 확인을 위한 요청 메소드
+     * @param token(String): "authorization" 헤더 키로 Jwt 토큰 값을 넣음
+     * @response - ResponseValidateJwt
+     * @author - Seunggun Sin
+     */
+    @POST(
+        "oauth2" +
+                "/validate-jwt"
+    )
+    fun requestValidationJwt(@Header("authorization") token: String): Response<ResponseValidateJwt>
 
     /**
      * OAuth2 구글 API 서버로부터 엑세스 토큰 요청 메소드
@@ -31,5 +60,5 @@ interface RetrofitService {
      * @author - Seunggun Sin
      */
     @POST("token")
-    fun requestGoogleAccessToken(@Body googleRequest: RequestGoogleAccessToken): Call<ResponseGoogleAccessToken>
+    suspend fun requestGoogleAccessToken(@Body googleRequest: RequestGoogleAccessToken): Response<ResponseGoogleAccessToken>
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
@@ -20,44 +20,41 @@ interface RetrofitService {
 
     /**
      * 구글 로그인 토큰 검증 요청 메소드
-     * @request - RequestGoogleToken
-     * @response - ResponseLogin
-     * @author - Seunggun Sin
+     * @request RequestGoogleToken
+     * @response ResponseLogin
+     * @author Seunggun Sin
      */
     @POST("oauth/sign-in/google")
-    suspend fun requestGoogleLogin(@Body tokens: RequestGoogleToken): Response<ResponseLogin>
+    fun requestGoogleLogin(@Body tokens: RequestGoogleToken): Call<ResponseLogin>
 
     /**
      * 최종 회원가입 요청 메소드 - Multipart 요청
      * @param image(MultipartBody.Part): 이미지가 담긴 multi form 요청 body (key=profileImg)
      * @param data(RequestBody): 나머지 텍스트 필드 값이 담긴 요청 body (key=signUpRequest)
-     * @response - String: 응답 body 자체는 중요 x, Jwt 토큰을 위한 헤더 값만 필요
-     * @author - Seunggun Sin
+     * @response Unit: 응답 body 자체는 중요 x, Jwt 토큰을 위한 헤더 값만 필요
+     * @author Seunggun Sin
      */
     @Multipart
     @POST("oauth2/sign-up")
-    fun requestSignUp(
+    suspend fun requestSignUp(
         @Part image: MultipartBody.Part,
         @Part("signUpRequest") data: RequestBody
-    ): Response<String>
+    ): Response<Unit>
 
     /**
      * 앱을 재시작하고 자동 로그인 시, Jwt 토큰 만료 확인을 위한 요청 메소드
      * @param token(String): "authorization" 헤더 키로 Jwt 토큰 값을 넣음
-     * @response - ResponseValidateJwt
-     * @author - Seunggun Sin
+     * @response ResponseJwtUserInfo (기본 유저 정보에 대한 DTO 클래스)
+     * @author Seunggun Sin
      */
-    @POST(
-        "oauth2" +
-                "/validate-jwt"
-    )
-    fun requestValidationJwt(@Header("authorization") token: String): Response<ResponseValidateJwt>
+    @POST("oauth2/validate-jwt")
+    suspend fun requestValidationJwt(@Header("Authorization") token: String): Response<ResponseJwtUserInfo>
 
     /**
      * OAuth2 구글 API 서버로부터 엑세스 토큰 요청 메소드
-     * @request - RequestGoogleAccessToken
-     * @response - ResponseGoogleAccessToken
-     * @author - Seunggun Sin
+     * @request RequestGoogleAccessToken
+     * @response ResponseGoogleAccessToken
+     * @author Seunggun Sin
      */
     @POST("token")
     suspend fun requestGoogleAccessToken(@Body googleRequest: RequestGoogleAccessToken): Response<ResponseGoogleAccessToken>

--- a/Breaking/app/src/main/java/com/dope/breaking/signup/Register.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/signup/Register.kt
@@ -1,0 +1,71 @@
+package com.dope.breaking.signup
+
+import android.graphics.Bitmap
+import com.dope.breaking.exception.ResponseErrorException
+import com.dope.breaking.model.RequestSignUp
+import com.dope.breaking.retrofit.RetrofitManager
+import com.dope.breaking.retrofit.RetrofitService
+import okhttp3.Headers
+import okhttp3.MediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import java.io.ByteArrayOutputStream
+import kotlin.jvm.Throws
+
+class Register {
+    private val multiPartFileName = "profileImg" // multi part 요청에 대한 key 이름
+
+    /**
+     * input 으로 받아온 회원가입 정보를 바탕으로 Request Body 생성 및 회원가입 요청하는 메소드
+     * @param inputData(RequestSignUp): 회원가입 필드에 대한 데이터 클래스 객체
+     * @param imageData(Bitmap): 프로필 이미지에 대한 bitmap 데이터
+     * @param imageName(String): 프로필 이미지의 파일 이름
+     * @throws ResponseErrorException: 정상 응답 (2xx) 이외의 응답이 왔을 때 exception 발생
+     * @return Headers: 응답에 대한 헤더 전체 데이터
+     * @author - Seunggun Sin
+     * @since - 2022-07-08 | 2022-07-09
+     */
+    @Throws(ResponseErrorException::class) // @Throws 어노테이션 사용 (Java 에서의 throws 키워드)
+    fun startRequestSignUp(
+        inputData: RequestSignUp,
+        imageData: Bitmap,
+        imageName: String
+    ): Headers {
+        // Retrofit 서비스 객체 생성
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+        // 이미지에 대한 RequestBody 생성 (image/*)
+        val imageRequestBody =
+            RequestBody.create(MediaType.parse("image/*"), convertBitmapToByte(imageData))
+        // 이미지에 대한 RequestBody 를 바탕으로 Multi form 데이터 생성
+        val imgFile =
+            MultipartBody.Part.createFormData(multiPartFileName, imageName, imageRequestBody)
+        // 나머지 필드에 대한 RequestBody 생성 (text/plain)
+        val data =
+            RequestBody.create(MediaType.parse("text/plain"), inputData.convertJsonToString())
+
+        // retrofit 이용하여 회원가입 요청
+        val response = service.requestSignUp(imgFile, data)
+
+        if (response.code() in 200..299) { // 요청이 성공적이라면
+            return response.headers() // 응답의 헤더 객체 리턴
+        } else { // 실패했다면
+            // 예외 던지기
+            throw ResponseErrorException("요청에 실패하였습니다. error: ${response.errorBody().toString()}")
+        }
+    }
+
+    /**
+     * Bitmap 데이터를 Byte Array 형태로 변환 (이미지 compression 포함)
+     * @param bitmap(Bitmap): Bitmap 타입의 이미지 데이터
+     * @param quality(Int): 이미지의 품질 (%) - default=100
+     * @return - ByteArray: 변환된 byte array
+     * @author - Seunggun Sin
+     * @since - 2022-07-09
+     */
+    private fun convertBitmapToByte(bitmap: Bitmap, quality: Int = 100): ByteArray {
+        val byteArrayOutputStream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.JPEG, quality, byteArrayOutputStream) // compression 및 변환
+        return byteArrayOutputStream.toByteArray()
+    }
+
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/signup/Register.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/signup/Register.kt
@@ -22,15 +22,16 @@ class Register {
      * @param imageName(String): 프로필 이미지의 파일 이름
      * @throws ResponseErrorException: 정상 응답 (2xx) 이외의 응답이 왔을 때 exception 발생
      * @return Headers: 응답에 대한 헤더 전체 데이터
-     * @author - Seunggun Sin
-     * @since - 2022-07-08 | 2022-07-09
+     * @author Seunggun Sin
+     * @since 2022-07-08 | 2022-07-09
      */
     @Throws(ResponseErrorException::class) // @Throws 어노테이션 사용 (Java 에서의 throws 키워드)
-    fun startRequestSignUp(
+    suspend fun startRequestSignUp(
         inputData: RequestSignUp,
         imageData: Bitmap,
         imageName: String
     ): Headers {
+
         // Retrofit 서비스 객체 생성
         val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
         // 이미지에 대한 RequestBody 생성 (image/*)
@@ -50,7 +51,7 @@ class Register {
             return response.headers() // 응답의 헤더 객체 리턴
         } else { // 실패했다면
             // 예외 던지기
-            throw ResponseErrorException("요청에 실패하였습니다. error: ${response.errorBody().toString()}")
+            throw ResponseErrorException("요청에 실패하였습니다. error: ${response.errorBody()?.string()}")
         }
     }
 
@@ -58,13 +59,17 @@ class Register {
      * Bitmap 데이터를 Byte Array 형태로 변환 (이미지 compression 포함)
      * @param bitmap(Bitmap): Bitmap 타입의 이미지 데이터
      * @param quality(Int): 이미지의 품질 (%) - default=100
-     * @return - ByteArray: 변환된 byte array
-     * @author - Seunggun Sin
-     * @since - 2022-07-09
+     * @return ByteArray: 변환된 byte array
+     * @author Seunggun Sin
+     * @since 2022-07-09
      */
     private fun convertBitmapToByte(bitmap: Bitmap, quality: Int = 100): ByteArray {
         val byteArrayOutputStream = ByteArrayOutputStream()
-        bitmap.compress(Bitmap.CompressFormat.JPEG, quality, byteArrayOutputStream) // compression 및 변환
+        bitmap.compress(
+            Bitmap.CompressFormat.JPEG,
+            quality,
+            byteArrayOutputStream
+        ) // compression 및 변환
         return byteArrayOutputStream.toByteArray()
     }
 

--- a/Breaking/app/src/main/java/com/dope/breaking/util/JwtTokenUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/JwtTokenUtil.kt
@@ -1,0 +1,63 @@
+package com.dope.breaking.util
+
+import android.content.Context
+import okhttp3.Headers
+
+/**
+ * Jwt 토큰과 관련된 처리를 하는 Util 클래스
+ * 필요에 따라 다양한 메소드 추가
+ * @param context(Context): 현재 컨텍스트
+ */
+class JwtTokenUtil(context: Context) {
+    private val fileName = "jwt" // SharedPreferences 의 파일 이름
+    private val keyName = "authorization" // 헤더 키 값
+    private val prefUtil = PreferenceUtil(context, fileName) // SharedPreferences Util 객체
+
+    /**
+     * 로컬 파일, 즉, SharedPreferences 로부터 토큰 값을 가져오는 메소드
+     * @param - None
+     * @return String?: 로컬에 저장된 jwt 토큰 값 리턴, 없다면 null 리턴
+     * @author - Seunggun Sin
+     * @since - 2022-07-09
+     */
+    fun getTokenFromLocal(): String? {
+        val value = prefUtil.getString("token", "none")
+        return if (value == "none") null else value
+    }
+
+    /**
+     * Http 요청의 응답의 헤더로부터 Jwt 토큰 값을 가져오는 메소드
+     * @param headers(Headers): 응답 헤더 객체
+     * @return String?: 헤더에 담긴 jwt 토큰 값 리턴, 없다면 null 리턴
+     * @author - Seunggun Sin
+     * @since - 2022-07-09
+     */
+    fun getTokenFromResponse(headers: Headers): String? {
+        return headers[keyName]
+    }
+
+    /**
+     * 로컬에 토큰 값을 저장하는 메소드 (key=token)
+     * @param token(String): 저장하고자 하는 jwt 토큰 문자열
+     * @return - None
+     * @author - Seunggun Sin
+     * @since - 2022-07-09
+     */
+    fun setToken(token: String) {
+        prefUtil.setString("token", token)
+    }
+
+    /**
+     * JWT 토큰이 있는지 없는지 판단. 헤더의 값이 null 이거나 빈 문자열이면 false 리턴, 값이 존재하면 true 리턴.
+     * @param headerName(String): jwt 토큰을 위한 헤더 key 값으로, "authorization"로 고정
+     * @param headers(Headers): 백엔드 서버로 요청의 결과로 받은 응답의 헤더 객체인 response.headers().
+     * @return 응답의 결과로 토큰이 있는지 없는지에 대한 bool 값 리턴
+     * @author - Seunggun Sin
+     * @since - 2022-07-07
+     */
+    fun hasJwtToken(headerName: String, headers: Headers): Boolean =
+    // Map 데이터로 인덱스 연산자에 문자열을 넣는 key-value 방식을 사용하여 헤더 map 데이터에 headerName 문자열을 넣었을 때
+        // 나오는 value 의 값이 null 이거나 빈 문자열이라면 false 리턴, 그렇지 않고 정상적인 값이 있으면 true 리턴
+        !(headers[headerName] == null || headers[headerName]!!.isEmpty())
+
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/util/JwtTokenUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/JwtTokenUtil.kt
@@ -1,7 +1,12 @@
 package com.dope.breaking.util
 
 import android.content.Context
+import com.dope.breaking.exception.ResponseErrorException
+import com.dope.breaking.model.ResponseJwtUserInfo
+import com.dope.breaking.retrofit.RetrofitManager
+import com.dope.breaking.retrofit.RetrofitService
 import okhttp3.Headers
+import kotlin.jvm.Throws
 
 /**
  * Jwt 토큰과 관련된 처리를 하는 Util 클래스
@@ -17,8 +22,8 @@ class JwtTokenUtil(context: Context) {
      * 로컬 파일, 즉, SharedPreferences 로부터 토큰 값을 가져오는 메소드
      * @param - None
      * @return String?: 로컬에 저장된 jwt 토큰 값 리턴, 없다면 null 리턴
-     * @author - Seunggun Sin
-     * @since - 2022-07-09
+     * @author Seunggun Sin
+     * @since 2022-07-09
      */
     fun getTokenFromLocal(): String? {
         val value = prefUtil.getString("token", "none")
@@ -26,11 +31,39 @@ class JwtTokenUtil(context: Context) {
     }
 
     /**
+     * 백엔드 서버에 Jwt 토큰 만료 확인 등, 재 로그인 및 자동 로그인에 사용되는 토큰 검증 메소드
+     * @param token(String): Jwt 토큰 문자열 값
+     * @return ResponseJwtUserInfo: 응답으로 받은 유저의 기본 정보 DTO 객체
+     * @throws ResponseErrorException: 정상 응답 (2xx) 이외의 응답이 왔을 때 exception 발생
+     * @author Seunggun Sin
+     * @since 2022-07-11
+     */
+    @Throws(ResponseErrorException::class)
+    suspend fun validateJwtToken(token: String): ResponseJwtUserInfo {
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+        val response = service.requestValidationJwt(token)
+
+        if (response.code() in 200..299) {
+            if (response.body() != null) {
+                return response.body()!!
+            } else {
+                throw ResponseErrorException("응답 Body가 존재하지 않습니다!")
+            }
+        } else {
+            throw ResponseErrorException(
+                "요청에 실패하였습니다. code: ${response.code()}\nerror: ${
+                    response.errorBody()?.string()
+                }"
+            )
+        }
+    }
+
+    /**
      * Http 요청의 응답의 헤더로부터 Jwt 토큰 값을 가져오는 메소드
      * @param headers(Headers): 응답 헤더 객체
      * @return String?: 헤더에 담긴 jwt 토큰 값 리턴, 없다면 null 리턴
-     * @author - Seunggun Sin
-     * @since - 2022-07-09
+     * @author Seunggun Sin
+     * @since 2022-07-09
      */
     fun getTokenFromResponse(headers: Headers): String? {
         return headers[keyName]
@@ -40,8 +73,8 @@ class JwtTokenUtil(context: Context) {
      * 로컬에 토큰 값을 저장하는 메소드 (key=token)
      * @param token(String): 저장하고자 하는 jwt 토큰 문자열
      * @return - None
-     * @author - Seunggun Sin
-     * @since - 2022-07-09
+     * @author Seunggun Sin
+     * @since 2022-07-09
      */
     fun setToken(token: String) {
         prefUtil.setString("token", token)
@@ -52,8 +85,8 @@ class JwtTokenUtil(context: Context) {
      * @param headerName(String): jwt 토큰을 위한 헤더 key 값으로, "authorization"로 고정
      * @param headers(Headers): 백엔드 서버로 요청의 결과로 받은 응답의 헤더 객체인 response.headers().
      * @return 응답의 결과로 토큰이 있는지 없는지에 대한 bool 값 리턴
-     * @author - Seunggun Sin
-     * @since - 2022-07-07
+     * @author Seunggun Sin
+     * @since 2022-07-07
      */
     fun hasJwtToken(headerName: String, headers: Headers): Boolean =
     // Map 데이터로 인덱스 연산자에 문자열을 넣는 key-value 방식을 사용하여 헤더 map 데이터에 headerName 문자열을 넣었을 때

--- a/Breaking/app/src/main/java/com/dope/breaking/util/PreferenceUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/PreferenceUtil.kt
@@ -1,0 +1,38 @@
+package com.dope.breaking.util
+
+import android.content.Context
+
+/**
+ * SharedPreferences 를 간단하게 사용하기 위한 util 클래스
+ * 필요에 따라 다양한 메소드 추가
+ * @param context(Context): 현재 컨텍스트
+ * @param name(String): SharedPreferences 에 저장할 파일 이름
+ */
+class PreferenceUtil(context: Context, name: String) {
+    // preference 객체 생성
+    private val pref = context.getSharedPreferences(name, Context.MODE_PRIVATE)
+
+    /**
+     * key 에 대한 문자열 value 반환
+     * @param key(String): value 값을 가져오기 위한 key 값
+     * @param default(String): key 에 대한 value 값이 없을 때 default 로 넘겨주는 value.
+     * @return - key 에 대응되는 value 값 리턴, key 에 대해 저장된 값이 없으면 default 리턴.
+     * @author - Seunggun Sin
+     * @since - 2022-07-08
+     */
+    fun getString(key: String, default: String): String {
+        return pref.getString(key, default).toString()
+    }
+
+    /**
+     * key 에 대한 문자열 value 를 저장
+     * @param key(String): key 값
+     * @param value(String): 문자열 value 값
+     * @return - None
+     * @author - Seunggun Sin
+     * @since - 2022-07-08
+     */
+    fun setString(key: String, value: String) {
+        pref.edit().putString(key, value).apply()
+    }
+}

--- a/Breaking/app/src/test/java/com/dope/breaking/RequestSignUpTest.kt
+++ b/Breaking/app/src/test/java/com/dope/breaking/RequestSignUpTest.kt
@@ -1,0 +1,13 @@
+package com.dope.breaking
+
+import com.dope.breaking.model.RequestSignUp
+import org.junit.Test
+
+class RequestSignUpTest {
+    @Test
+    fun `클래스에서 if문 초기화가 바로 적용 되는지 테스트`() {
+        val result = RequestSignUp("a", "b", "c", "d", "e", "f", true)
+        assert(result.role == "USER")
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #20 

## 예상 리뷰 시간
30-min

## 추가 또는 변경사항
- 회원가입에 필요한 데이터들을 받는 요청 함수 생성
- 받은 데이터들을 바탕으로 백엔드 서버로 multipart 회원가입 요청(테스트 데이터 생성해서 테스트 회원가입 요청)
- 회원가입 요청으로 받은 응답의 헤더에서 Jwt 토큰 값 추출하여 로컬에 저장
- 회원가입 시, 받은 Jwt 토큰으로 유저의 기본 정보 요청하여 받아오기
- jwt, preference 등 util 클래스 생성
- 에러 처리를 커스텀 Exception 클래스를 생성하여 분리
- 페이지 이동 기능 (로그인 → 회원가입, 회원가입 → 메인(임시))
- Retrofit2 Interface의 응답으로 Call 방식에서 Response 방식 전환(일부는 Call 사용)
- GoogleLogin 클래스 및 일부 클래스에서 사용된 코루틴(async/await) 삭제

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
- 요청 데이터
![image](https://user-images.githubusercontent.com/54919474/178260517-7ffce83b-fe41-42b6-ae9c-850dbac05f74.png)
- 회원가입 요청에 대한 응답 헤더
![image](https://user-images.githubusercontent.com/54919474/178260594-ea6a3b73-3c11-4cdb-bb06-69dfc839119e.png)
- Jwt 토큰을 사용한 유저 정보 응답 값
![image](https://user-images.githubusercontent.com/54919474/178260633-98de6e84-9028-4ab3-aa37-7acf120b628b.png)


## 기타
- Multipart 요청
  - Retrofit에서의 Multipart 요청은 @Multipart 어노테이션을 메소드 상단에 사용하고, 바디에 들어가는 값은 @Part(or @PartXXX....) 를 사용한다. 이미지나 동영상같은 데이터는 `MultipartBody.Part` 타입의 데이터를 사용해서 파라미터로 넣어준다. 
  - 이번 요청의 경우 회원가입 요청 시, 응답으로 헤더만 오고 body값은 오지 않는다. 그런데 Response 방식으로 하면 값이 없으므로 매핑되는 응답 값이 맞지 않는 문제가 발생했다. 이를 해결하기 위해 Unit 타입을 응답 타입으로 지정해줌으로써 해결했다.
- Retrofit
  - 코루틴에 대해 살펴보다가 코루틴과 retrofit의 결합(?)을 봤는데, Call 방식이 아니라 Response 방식을 사용할 수 있다는 것을 알게 되었다. 그렇게하면 바로 응답의 결과를 받을 수 있다. 
  - 하지만 그에 대한 문제가 있었는데, 보통 응답에 해당하는 DTO 클래스를 생성해두는데, 만약에 응답의 형태가 일관성 없는 경우라면 데이터가 각 필드에 맵핑되지 않을 것이다. 그렇게 함으로써 에러가 발생하게 된다. 그렇기 때문에 Response 방식을 사용하면 데이터가 바로 리턴되기 때문에 만약에 대응되는 응답이 아닐 경우에는 Gson에 의한 에러가 발생하게 된다. 그렇기에 여러가지 응답의 경우의 수가 있을 때에는 Call 방식을 사용하여 응답 객체의 code()를 활용하여 정상적인 응답인지 아닌지 판단해서 대응되는 데이터일 때 할당해주는 식을 처리해줘야한다. 
  - 추가적으로 Response 방식을 사용할 때에는 함수 앞에 `suspend` 키워드를 붙여줘야하고, Call 방식일 때는 붙여주면 안된다. 
- Exception
  - View에서 정상처리, 에러처리를 해줘야 하는데, 조건문등 으로 일일이 경우를 다 구분해서 쓰다보면 코드가 클린해보이지 않을 것 같다는 생각이 들어서 따로 새로운 Exception 클래스를 만들어둬서 로직 부분에 해당하는 메소드에서 그 경우에 해당하는 에러가 발생했을 경우에 throw를 하고 그 예외처리를 이 메소드를 호출하는 쪽에 넘겨주는 throws(코틀린에서는 @Throws)를 사용하여 try/catch로 처리해주는 방식을 채택했다. 
- Test code
  - 아주 간단한거긴 하지만 JUnit을 사용하여 테스트 코드를 한번 사용해보았다. 처음에는 테스트 코드의 필요성을 못느꼈었는데, 실제 사용 환경에서 여러가지 사항을 고려하여 세팅해서 테스트해야되는 상황에서는 테스트 코드가 나름 편리하다는 느낌을 받았다. 