### PR TITLE
feat: handle exception view for google login and sign-up

### DIFF
--- a/Breaking/app/src/main/java/com/dope/breaking/SignUpActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/SignUpActivity.kt
@@ -262,7 +262,7 @@ class SignUpActivity : AppCompatActivity() {
 
             // 닉네임, 전화번호, 이메일의 유효성 검증 요청
             val progressDialog = DialogUtil().ProgressDialog(this)
-            progressDialog.showDialog() // 로딩 progress 시작
+            progressDialog.showDialog()
 
             CoroutineScope(Dispatchers.Main).launch {
                 val validation = Validation()
@@ -290,6 +290,10 @@ class SignUpActivity : AppCompatActivity() {
                     )
                     Log.d(TAG, "filename test : " + filename)
 
+                    if (progressDialog.isShowing()) { // 로딩 progress 종료
+                        progressDialog.dismissDialog()
+                    }
+                } else {
                     if (progressDialog.isShowing()) { // 로딩 progress 종료
                         progressDialog.dismissDialog()
                     }

--- a/Breaking/app/src/main/java/com/dope/breaking/SignUpActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/SignUpActivity.kt
@@ -30,8 +30,8 @@ import com.dope.breaking.util.Utils.setImageWithGlide
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.util.regex.Pattern
 import com.dope.breaking.model.response.ResponseExistLogin
+import com.dope.breaking.util.DialogUtil
 
 
 class SignUpActivity : AppCompatActivity() {
@@ -189,9 +189,23 @@ class SignUpActivity : AppCompatActivity() {
             }
         } catch (e: ResponseErrorException) {
             e.printStackTrace()
+            DialogUtil().SingleDialog(
+                this,
+                "회원가입 요청에 문제가 발생하였습니다.",
+                "확인"
+            ) {
+
+            }.show()
             // 응답 에러에 대한 예외 처리하기
         } catch (e: MissingJwtTokenException) {
             // 토큰 값이 존재하지 않을 때에 대한 예외 처리하기
+            DialogUtil().SingleDialog(
+                this,
+                "회원가입 정보를 불러오는데 실패하였습니다.",
+                "확인"
+            ) {
+
+            }.show()
         }
     }
 
@@ -247,6 +261,9 @@ class SignUpActivity : AppCompatActivity() {
             )
 
             // 닉네임, 전화번호, 이메일의 유효성 검증 요청
+            val progressDialog = DialogUtil().ProgressDialog(this)
+            progressDialog.showDialog() // 로딩 progress 시작
+
             CoroutineScope(Dispatchers.Main).launch {
                 val validation = Validation()
                 validationResult =
@@ -272,6 +289,10 @@ class SignUpActivity : AppCompatActivity() {
                         imageName = filename ?: "default.png"
                     )
                     Log.d(TAG, "filename test : " + filename)
+
+                    if (progressDialog.isShowing()) { // 로딩 progress 종료
+                        progressDialog.dismissDialog()
+                    }
                 }
             }
         })

--- a/Breaking/app/src/main/java/com/dope/breaking/SplashActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/SplashActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
+import com.dope.breaking.exception.ResponseErrorException
 import com.dope.breaking.util.JwtTokenUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -29,18 +30,25 @@ class SplashActivity : AppCompatActivity() {
 
                 // 로컬에 Jwt 토큰이 저장되어 있다면
                 if (jwtTokenUtil.getTokenFromLocal() != null) {
-                    Log.d(TAG, "TEST1 : "+jwtTokenUtil.getTokenFromLocal())
+                    Log.d(TAG, "TEST1 : " + jwtTokenUtil.getTokenFromLocal())
                     // Jwt 토큰을 이용해 기본 유저 정보 요청
-                    val userData =
-                        jwtTokenUtil.validateJwtToken("Bearer " + jwtTokenUtil.getTokenFromLocal()!!)
+                    try {
+                        val userData =
+                            jwtTokenUtil.validateJwtToken("Bearer " + jwtTokenUtil.getTokenFromLocal()!!)
 
-                    // 메인 페이지로 유저 데이터와 함께 이동
-                    val intent = Intent(applicationContext, MainActivity::class.java)
-                    intent.putExtra("userInfo", userData)
-                    intent.flags =
-                        Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-                    startActivity(intent)
-                    overridePendingTransition(R.anim.fade_in, R.anim.fade_out)
+                        // 메인 페이지로 유저 데이터와 함께 이동
+                        val intent = Intent(applicationContext, MainActivity::class.java)
+                        intent.putExtra("userInfo", userData)
+                        intent.flags =
+                            Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                        startActivity(intent)
+                        overridePendingTransition(R.anim.fade_in, R.anim.fade_out)
+                    } catch (e: ResponseErrorException) { // 토큰은 있는데 계정 정보가 없을 때 처리
+                        val intent = Intent(applicationContext, SignInActivity::class.java)
+                        startActivity(intent)
+                        overridePendingTransition(R.anim.fade_in, R.anim.fade_out)
+                        finish()
+                    }
                 } else { // 로컬에 토큰이 저장되어 있지않다면
                     // 로그인 페이지로 이동
                     Log.d(TAG, "TEST2")

--- a/Breaking/app/src/main/java/com/dope/breaking/util/DialogUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/DialogUtil.kt
@@ -1,0 +1,118 @@
+package com.dope.breaking.util
+
+import android.app.Activity
+import android.app.AlertDialog
+import android.app.Dialog
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.WindowManager
+import android.widget.Button
+import android.widget.TextView
+import com.dope.breaking.R
+
+/**
+ * AlertDialog 에 대한 Util 클래스
+ * 원하는 Dialog 를 inner class 로 커스터마이징하여 구현함으로써 간편하게 사용
+ */
+class DialogUtil {
+    /**
+     * 텍스트 컨텐츠 하나와 단일 버튼으로 이루어진 Dialog
+     * @param context(Context): 이 Dialog 가 보여지고자 하는 컨텍스트(위치)
+     * @param content(String): 컨텐츠 텍스트 문자열
+     * @param buttonText(String): 버튼 텍스트 문자열
+     * @param event(() -> Unit): 버튼 클릭 시 실행할 함수
+     */
+    inner class SingleDialog(
+        context: Context,
+        private val content: String,
+        private val buttonText: String,
+        private val event: () -> Unit
+    ) : Dialog(context) {
+
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
+
+            setContentView(R.layout.custom_dialog_single_button)
+            window!!.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+            setCanceledOnTouchOutside(false)
+
+            val textView = findViewById<TextView>(R.id.tv_dialog_content)
+            textView.text = content
+
+            val button = findViewById<Button>(R.id.btn_dialog_single_ok)
+            button.text = buttonText
+            button.setOnClickListener {
+                event()
+                dismiss()
+            }
+        }
+    }
+
+    /**
+     * 텍스트 컨텐츠 하나와 두개의 버튼으로 이루어진 Dialog
+     */
+    inner class MultipleDialog(context: Context) : Dialog(context) {
+
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
+            setContentView(R.layout.custom_dialog_multiple_button)
+            window!!.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+            setCanceledOnTouchOutside(false)
+        }
+    }
+
+    /**
+     * 로딩창에 사용하기위한 Progress Dialog
+     * @param activity(Activity): Dialog 가 실행되는 액티비티
+     */
+    inner class ProgressDialog(private val activity: Activity) {
+        private lateinit var dialog: AlertDialog
+
+        /**
+         * 로딩 창을 시작하는 함수
+         * @author Seunggun Sin
+         * @since 2022-07-18 | 2022-07-19
+         */
+        fun showDialog() {
+            val builder = AlertDialog.Builder(activity)
+            val inflater = activity.layoutInflater
+            builder.setView(inflater.inflate(R.layout.progress_dialog_layout, null))
+            dialog = builder.create()
+
+            dialog.setCanceledOnTouchOutside(false) // 외부 터치에 의한 Dialog 종료 방지
+            dialog.window!!.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT)) // Dialog 내용 자체를 투명하게
+            dialog.window!!.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND) // 외부 배경을 투명하게
+
+            dialog.show()
+        }
+
+        /**
+         * 로딩 창을 종료하는 함수 (showDialog 함수가 먼저 호출이 되어야 함. 그렇지 않으면 Exception 발생)
+         * @author Seunggun Sin
+         * @since 2022-07-18 | 2022-07-19
+         */
+        fun dismissDialog() {
+            try {
+                dialog.dismiss()
+            } catch (e: UninitializedPropertyAccessException) {
+                e.printStackTrace()
+            }
+        }
+
+        /**
+         * 현재 로딩 창이 보여지고 있는지 없는지 체크해주는 함수
+         * @return 보여지고 있으면 true, 아니면 false
+         * @author Seunggun Sin
+         * @since 2022-07-19
+         */
+        fun isShowing(): Boolean {
+            return try {
+                dialog.isShowing
+            } catch (e: UninitializedPropertyAccessException) {
+                false
+            }
+        }
+    }
+}

--- a/Breaking/app/src/main/res/drawable/custom_dialog_background.xml
+++ b/Breaking/app/src/main/res/drawable/custom_dialog_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:radius="8dip"/>
+            <solid android:color="@color/white"/>
+            <stroke android:width="0dp" android:color="@color/white"/>
+        </shape>
+    </item>
+</layer-list>

--- a/Breaking/app/src/main/res/drawable/custom_dialog_multi_left_background.xml
+++ b/Breaking/app/src/main/res/drawable/custom_dialog_multi_left_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners
+        android:bottomLeftRadius="8dip" />
+    <solid android:color="@color/sign_up_user_type_text_color" />
+    <stroke android:width="0.5dp" android:color="@color/black"/>
+</shape>

--- a/Breaking/app/src/main/res/drawable/custom_dialog_multi_right_background.xml
+++ b/Breaking/app/src/main/res/drawable/custom_dialog_multi_right_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners
+        android:bottomRightRadius="8dip" />
+    <solid android:color="@color/sign_up_user_type_text_color" />
+    <stroke android:width="0.5dp"  android:color="@color/black"/>
+</shape>

--- a/Breaking/app/src/main/res/drawable/theme_button_background.xml
+++ b/Breaking/app/src/main/res/drawable/theme_button_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners
+        android:bottomLeftRadius="8dip"
+        android:bottomRightRadius="8dip" />
+    <solid android:color="@color/sign_up_user_type_text_color" />
+    <stroke android:width="0dp" />
+</shape>

--- a/Breaking/app/src/main/res/layout/custom_dialog_multiple_button.xml
+++ b/Breaking/app/src/main/res/layout/custom_dialog_multiple_button.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:background="@drawable/custom_dialog_background"
+    android:layout_height="match_parent"
+    >
+    <TextView
+        android:id="@+id/tv_dialog_content"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="5dp"
+        android:gravity="center"
+        android:padding="15dp"
+        android:textColor="@color/white"
+        android:textSize="14sp"
+        android:textStyle="bold" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+        <Button
+            android:id="@+id/btn_dialog_multi_left"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:background="@drawable/custom_dialog_multi_left_background"
+            android:textColor="@color/white"
+            android:textSize="11sp"/>
+        <Button
+            android:id="@+id/btn_dialog_multi_right"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:background="@drawable/custom_dialog_multi_right_background"
+            android:textColor="@color/white"
+            android:textSize="11sp" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/Breaking/app/src/main/res/layout/custom_dialog_multiple_button.xml
+++ b/Breaking/app/src/main/res/layout/custom_dialog_multiple_button.xml
@@ -12,7 +12,7 @@
         android:layout_margin="5dp"
         android:gravity="center"
         android:padding="15dp"
-        android:textColor="@color/white"
+        android:textColor="@color/black"
         android:textSize="14sp"
         android:textStyle="bold" />
     <LinearLayout

--- a/Breaking/app/src/main/res/layout/custom_dialog_single_button.xml
+++ b/Breaking/app/src/main/res/layout/custom_dialog_single_button.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/custom_dialog_background"
+    android:orientation="vertical">
+    <TextView
+        android:id="@+id/tv_dialog_content"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="25dp"
+        android:textColor="@color/white"
+        android:textSize="13sp"
+        android:textStyle="bold" />
+    <Button
+        android:id="@+id/btn_dialog_single_ok"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/theme_button_background"
+        android:textColor="@color/white"
+        android:textSize="11sp" />
+</LinearLayout>

--- a/Breaking/app/src/main/res/layout/custom_dialog_single_button.xml
+++ b/Breaking/app/src/main/res/layout/custom_dialog_single_button.xml
@@ -10,7 +10,7 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:padding="25dp"
-        android:textColor="@color/white"
+        android:textColor="@color/black"
         android:textSize="13sp"
         android:textStyle="bold" />
     <Button

--- a/Breaking/app/src/main/res/layout/progress_dialog_layout.xml
+++ b/Breaking/app/src/main/res/layout/progress_dialog_layout.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <ProgressBar
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        style="?android:attr/progressBarStyle"/>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #34

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
- 다양한 AlertDialog를 사용할 수 있도록 하는 커스터마이징 Dialog Util 클래스 생성
  - 네트워크 작업 시 보여주는 로딩창 Dialog 추가
  - Dialog 디자인
- 로그인 시, 회원가입 시 발생하는 Exception에 대한 try/catch에 각각 대응되는 Dialog 띄우기
- 사소한 예외처리는 Toast 메세지로 처리
- Splash 페이지에서 Jwt 토큰을 검증할 때, Jwt 토큰은 있지만 회원가입된 정보는 없을 때에 대한 예외 처리 추가
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img src = "https://user-images.githubusercontent.com/54919474/179667875-df57e7ad-567f-449e-b5dd-42c6ca4725bf.png" width="30%" height="30%">
<img src = "https://user-images.githubusercontent.com/54919474/179667882-71f25de5-7861-410c-9b58-59956293ca5e.png" width="30%" height="30%">
<img src = "https://user-images.githubusercontent.com/54919474/179667890-912c76ca-c018-48d6-a0e2-a5052d4d4dc3.png" width="30%" height="30%">
<img src = "https://user-images.githubusercontent.com/54919474/179667913-de344a07-f1ce-4253-ba7e-68b1a06a36f4.png" width="30%" height="30%">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 각 에러 응답에 대해 Dialog에 보여줄 메세지에 대해 정확히 사용자에게 어떤 메세지를 보여줘야 잘 전달이 될까에 대한 고민이 필요해보임.
- ResponseErrorException의 경우 어떤 에러인지에 대해서는 구분하기가 어려워 추가적인 조치가 필요할지 고민이 됨. 
- Progress Dialog 디자인이 필요해보임.