### PR TITLE
style: implement Post Page Layout

### DIFF
--- a/Breaking/app/src/main/AndroidManifest.xml
+++ b/Breaking/app/src/main/AndroidManifest.xml
@@ -21,6 +21,9 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
+            android:name=".board.PostActivity"
+            android:exported="false"/>
+        <activity
             android:name=".NaviSettingActivity"
             android:exported="false" />
         <activity

--- a/Breaking/app/src/main/java/com/dope/breaking/board/PostActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/board/PostActivity.kt
@@ -1,0 +1,76 @@
+package com.dope.breaking.board
+
+import android.os.Bundle
+import android.view.MenuItem
+import android.view.MotionEvent
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import com.dope.breaking.R
+import com.dope.breaking.databinding.ActivityPostBinding
+
+
+class PostActivity : AppCompatActivity() {
+
+    private val TAG = "PostActivity.kt" // Tag Log
+
+    private var mbinding : ActivityPostBinding? = null
+
+    private val binding get() = mbinding!!
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        mbinding = ActivityPostBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        settingPostToolBar()  // 툴 바 설정
+        allowScrollEditText() // EditText 스크롤 터치 이벤트 허용
+    }
+
+    /**
+    @description - activity_post.xml에서 이미 최상위에 NestedScrollView가 정의되어 있기 때문에 EditText에 스크롤 옵션을 주어도 이벤트가 막히는 현상이 발생한다.
+                   따라서 해당 메소드를 통해 EditText 가 터치되어있을 때 부모의 스크롤 권한을 가로채고, EditText가 아닌 바깥을 터치한다면 다시 부모 스크롤 뷰가 동작하도록
+                   하는 메소드.
+    @param - None
+    @return - None
+    @author - Tae hyun Park
+    @since - 2022-07-25
+     */
+    private fun allowScrollEditText(){
+        // EditText 스크롤 터지 이벤트 리스너
+        binding.etContent.setOnTouchListener(object : View.OnTouchListener{
+            override fun onTouch(v: View?, event: MotionEvent?): Boolean {
+                if (v!!.id === R.id.et_content) { // 안쪽 EditText 를 클릭했다면
+                    v!!.parent.requestDisallowInterceptTouchEvent(true) // 부모 뷰의 스크롤 이벤트 비허용
+                    when (event!!.action and MotionEvent.ACTION_MASK) { // 만약 바깥 이벤트가 클릭되었다면
+                        MotionEvent.ACTION_UP -> v!!.parent.requestDisallowInterceptTouchEvent(false) // 부모 뷰의 스크롤 이벤트 허용
+                    }
+                }
+                return false
+            }
+        })
+    }
+
+    /**
+    @description - 제보하기 페이지 상단 툴 바에 대한 설정 메소드
+    @param - None
+    @return - None
+    @author - Tae hyun Park
+    @since - 2022-07-25
+     */
+    private fun settingPostToolBar(){
+        setSupportActionBar(binding.postPageToolBar) // 툴 바 설정
+        supportActionBar!!.setDisplayHomeAsUpEnabled(true) // 왼쪽 상단 버튼 만들기
+        supportActionBar!!.setHomeAsUpIndicator(R.drawable.ic_baseline_arrow_back_24) // 왼쪽 상단 아이콘
+        supportActionBar!!.setDisplayShowTitleEnabled(true) // 툴 바에 타이틀 보이게
+    }
+
+    // 툴 바의 item 선택 이벤트 리스너
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when(item.itemId){
+            android.R.id.home -> { // 툴 바의 뒤로가기 키가 눌렸을 때 동작
+                finish()
+                true
+            }
+        }
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviHomeFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviHomeFragment.kt
@@ -1,18 +1,30 @@
 package com.dope.breaking.fragment
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.*
 import androidx.fragment.app.Fragment
 import com.dope.breaking.R
+import com.dope.breaking.board.PostActivity
+import com.dope.breaking.databinding.FragmentNaviHomeBinding
 
 class NaviHomeFragment : Fragment() {
+    private var mbinding: FragmentNaviHomeBinding? = null // 바인딩 변수 초기화
+    private val binding get() = mbinding!! // 바인딩 변수 재할당
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_navi_home, container, false)
+        mbinding = FragmentNaviHomeBinding.inflate(inflater, container, false)
+        // 제보하기 버튼을 누르면 게시글 작성 페이지로 이동
+        binding.fabPosting.setOnClickListener {
+            var intent = Intent(activity, PostActivity::class.java)
+            startActivity(intent)
+        }
+        return binding.root
     }
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        activity?.menuInflater?.inflate(R.menu.general_title_menu, menu)
+        activity?.menuInflater?.inflate(R.menu.general_title_menu, menu) // 툴 바 아이콘 변경
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
@@ -81,7 +81,7 @@ interface RetrofitService {
      * @response ResponseJwtUserInfo (기본 유저 정보에 대한 DTO 클래스)
      * @author Seunggun Sin
      */
-    @POST("oauth2/validate-jwt")
+    @GET("oauth2/validate-jwt")
     suspend fun requestValidationJwt(@Header("Authorization") token: String): Response<ResponseExistLogin>
 
     /**

--- a/Breaking/app/src/main/res/drawable/btn_post_round.xml
+++ b/Breaking/app/src/main/res/drawable/btn_post_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/breaking_drawer_color"/>
+    <corners android:radius="8dp"/>
+</shape>

--- a/Breaking/app/src/main/res/drawable/ic_baseline_arrow_back_24.xml
+++ b/Breaking/app/src/main/res/drawable/ic_baseline_arrow_back_24.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/Breaking/app/src/main/res/drawable/ic_baseline_camera_alt_24.xml
+++ b/Breaking/app/src/main/res/drawable/ic_baseline_camera_alt_24.xml
@@ -1,0 +1,6 @@
+<vector android:height="60dp" android:tint="@color/white"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="60dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/breaking_color" android:pathData="M12,12m-3.2,0a3.2,3.2 0,1 1,6.4 0a3.2,3.2 0,1 1,-6.4 0"/>
+    <path android:fillColor="@color/breaking_color" android:pathData="M9,2L7.17,4L4,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2h-3.17L15,2L9,2zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5z"/>
+</vector>

--- a/Breaking/app/src/main/res/drawable/ic_baseline_location_on_24.xml
+++ b/Breaking/app/src/main/res/drawable/ic_baseline_location_on_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="@color/breaking_color"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z"/>
+</vector>

--- a/Breaking/app/src/main/res/drawable/post_input_background.xml
+++ b/Breaking/app/src/main/res/drawable/post_input_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#F1EEEE"/>
+    <corners android:radius="8dp"/>
+</shape>

--- a/Breaking/app/src/main/res/drawable/post_input_content_background.xml
+++ b/Breaking/app/src/main/res/drawable/post_input_content_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white"/>
+    <corners android:radius="3dp"/>
+</shape>

--- a/Breaking/app/src/main/res/layout/activity_post.xml
+++ b/Breaking/app/src/main/res/layout/activity_post.xml
@@ -1,0 +1,437 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/post_page_tool_bar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:theme="?attr/actionBarTheme"
+            android:background="@color/white"
+            android:elevation="4dp"
+            app:title="@string/post_register_btn"
+            app:titleTextColor="@color/black"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+        </androidx.appcompat.widget.Toolbar>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            tools:context=".board.PostActivity">
+
+            <TextView
+                android:id="@+id/tv_upload_picture"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/post_register_image_video"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                android:textColor="@color/black"
+                app:layout_constraintHorizontal_bias="0.1"
+                app:layout_constraintVertical_bias="0.02"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent" />
+
+            <LinearLayout
+                android:id="@+id/layout_image_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:background="@drawable/post_input_background"
+                android:layout_marginTop="15dp"
+                android:padding="5dp"
+                app:layout_constraintHorizontal_bias="0"
+                app:layout_constraintLeft_toLeftOf="@+id/tv_upload_picture"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tv_upload_picture"
+                app:layout_constraintBottom_toTopOf="@+id/divider1">
+
+                <ImageButton
+                    android:id="@+id/ib_upload_picture"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/ic_baseline_camera_alt_24" />
+
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/tv_current_count_image"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="0"/>
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="/"/>
+                    <TextView
+                        android:id="@+id/tv_total_count_image"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="10"/>
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/view_recycler_image"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:orientation="horizontal"
+                app:layout_constraintWidth_percent="0.6"
+                app:layout_constraintHorizontal_bias="0.507"
+                app:layout_constraintVertical_bias="0.0"
+                app:layout_constraintLeft_toRightOf="@+id/layout_image_button"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/layout_image_button"
+                app:layout_constraintBottom_toBottomOf="@+id/layout_image_button">
+            </androidx.recyclerview.widget.RecyclerView>
+
+<!--            <ProgressBar-->
+<!--                android:id="@+id/bar_progress_image"-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                style="@style/Widget.AppCompat.ProgressBar.Horizontal"-->
+<!--                app:layout_constraintWidth_percent="0.7"-->
+<!--                app:layout_constraintVertical_bias="0.3"-->
+<!--                app:layout_constraintLeft_toRightOf="@+id/layout_image_button"-->
+<!--                app:layout_constraintRight_toRightOf="parent"-->
+<!--                app:layout_constraintTop_toBottomOf="@+id/view_recycler_image"-->
+<!--                app:layout_constraintBottom_toBottomOf="@+id/layout_image_button">-->
+<!--            </ProgressBar>-->
+
+            <View
+                android:id="@+id/divider1"
+                android:layout_width="0dp"
+                android:layout_height="0.5dp"
+                android:layout_marginTop="25dp"
+                android:background="@color/gray"
+                app:layout_constraintTop_toBottomOf="@id/layout_image_button"
+                app:layout_constraintLeft_toLeftOf="@+id/layout_image_button"
+                app:layout_constraintRight_toRightOf="@+id/view_recycler_image"/>
+
+            <TextView
+                android:id="@+id/tv_event_time"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:text="@string/post_register_event_time"
+                android:textColor="@color/black"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toTopOf="@+id/tv_event_time_clicked"
+                app:layout_constraintLeft_toLeftOf="@+id/divider1"
+                app:layout_constraintTop_toBottomOf="@+id/divider1" />
+
+            <TextView
+                android:id="@+id/tv_event_time_clicked"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:background="@drawable/post_input_background"
+                android:hint="2022년 6월 1일 오후 7시 50분"
+                android:padding="7dp"
+                android:textSize="16sp"
+                android:textStyle="normal"
+                app:layout_constraintLeft_toLeftOf="@+id/tv_event_time"
+                app:layout_constraintTop_toBottomOf="@+id/tv_event_time" />
+
+            <TextView
+                android:id="@+id/tv_location"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="30dp"
+                android:text="@string/post_register_location"
+                android:textColor="@color/black"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                app:layout_constraintHorizontal_bias="0"
+                app:layout_constraintLeft_toLeftOf="@+id/tv_event_time_clicked"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tv_event_time_clicked"
+                app:layout_constraintBottom_toTopOf="@+id/tv_location_show"/>
+
+            <ImageView
+                android:id="@+id/tv_location_icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="30dp"
+                android:background="@drawable/ic_baseline_location_on_24"
+                app:layout_constraintHorizontal_bias="0.02"
+                app:layout_constraintLeft_toRightOf="@+id/tv_location"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tv_event_time_clicked"
+                app:layout_constraintBottom_toBottomOf="@+id/tv_location"/>
+
+            <TextView
+                android:id="@+id/tv_location_icon_text"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_marginTop="30dp"
+                android:text="@string/post_register_click_location"
+                android:textColor="@color/breaking_color"
+                android:textSize="12sp"
+                android:textStyle="bold"
+                android:gravity="center"
+                app:layout_constraintHorizontal_bias="0.01"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintLeft_toRightOf="@+id/tv_location_icon"
+                app:layout_constraintTop_toBottomOf="@+id/tv_event_time_clicked"
+                app:layout_constraintBottom_toBottomOf="@+id/tv_location"/>
+
+            <TextView
+                android:id="@+id/tv_location_show"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:background="@drawable/post_input_background"
+                android:hint="경기도 성남시 태평로 9"
+                android:padding="7dp"
+                android:textSize="16sp"
+                android:textStyle="normal"
+                app:layout_constraintLeft_toLeftOf="@+id/tv_location"
+                app:layout_constraintTop_toBottomOf="@+id/tv_location" />
+
+            <TextView
+                android:id="@+id/tv_post"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="30dp"
+                android:text="@string/post_register_title"
+                android:textColor="@color/black"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toTopOf="@+id/layout_post_title_content"
+                app:layout_constraintLeft_toLeftOf="@+id/tv_location_show"
+                app:layout_constraintTop_toBottomOf="@+id/tv_location_show" />
+
+            <LinearLayout
+                android:id="@+id/layout_post_title_content"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:orientation="vertical"
+                app:layout_constraintLeft_toLeftOf="@+id/tv_post"
+                app:layout_constraintRight_toRightOf="@+id/divider1"
+                app:layout_constraintTop_toBottomOf="@+id/tv_post">
+
+                <EditText
+                    android:id="@+id/et_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="0dp"
+                    android:padding="5dp"
+                    android:textSize="16sp"
+                    android:background="@drawable/post_input_background"
+                    android:hint="@string/post_register_content_title"
+                    android:lines="1"
+                    android:inputType="text"
+                    android:maxLength="30"/>
+
+                <EditText
+                    android:id="@+id/et_content"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:padding="5dp"
+                    android:textSize="16sp"
+                    android:background="@drawable/post_input_background"
+                    android:hint="@string/post_register_content_description"
+                    android:lines="15"
+                    android:scrollbars="vertical"
+                    android:maxLength="2000"/>
+
+                <EditText
+                    android:id="@+id/et_hashtag"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:padding="5dp"
+                    android:textSize="16sp"
+                    android:background="@drawable/post_input_background"
+                    android:hint="@string/post_register_content_hashtag"
+                    android:lines="1"
+                    android:inputType="text"
+                    android:maxLength="30"/>
+
+            </LinearLayout>
+
+            <View
+                android:id="@+id/divider2"
+                android:layout_width="0dp"
+                android:layout_height="0.5dp"
+                android:layout_marginTop="25dp"
+                android:background="@color/gray"
+                app:layout_constraintTop_toBottomOf="@id/layout_post_title_content"
+                app:layout_constraintLeft_toLeftOf="@+id/layout_post_title_content"
+                app:layout_constraintRight_toRightOf="@+id/layout_post_title_content"/>
+
+            <TextView
+                android:id="@+id/tv_post_type"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:text="@string/post_register_type"
+                android:textColor="@color/black"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                app:layout_constraintLeft_toLeftOf="@+id/divider2"
+                app:layout_constraintTop_toBottomOf="@+id/divider2"
+                app:layout_constraintBottom_toTopOf="@+id/btn_post_type_charged"/>
+
+            <Button
+                android:id="@+id/btn_post_type_charged"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginTop="10dp"
+                android:text="@string/post_register_type_charged"
+                android:background="@drawable/sign_up_user_type_selected"
+                app:layout_constraintHorizontal_bias="0"
+                app:layout_constraintWidth_percent="0.165"
+                app:layout_constraintHeight_percent="0.03"
+                app:layout_constraintLeft_toLeftOf="@+id/tv_post_type"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tv_post_type" />
+
+            <Button
+                android:id="@+id/btn_post_type_free"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginStart="19dp"
+                android:text="@string/post_register_type_free"
+                android:background="@drawable/sign_up_user_type_unselected"
+                app:layout_constraintHorizontal_bias="0"
+                app:layout_constraintWidth_percent="0.165"
+                app:layout_constraintHeight_percent="0.03"
+                app:layout_constraintLeft_toRightOf="@+id/btn_post_type_charged"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tv_post_type"
+                app:layout_constraintBottom_toBottomOf="@+id/btn_post_type_charged" />
+
+            <Button
+                android:id="@+id/btn_post_type_exclusive"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginStart="19dp"
+                android:text="@string/post_register_type_exclusive"
+                android:background="@drawable/sign_up_user_type_unselected"
+                app:layout_constraintHorizontal_bias="0"
+                app:layout_constraintWidth_percent="0.165"
+                app:layout_constraintHeight_percent="0.03"
+                app:layout_constraintLeft_toRightOf="@+id/btn_post_type_free"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tv_post_type"
+                app:layout_constraintBottom_toBottomOf="@+id/btn_post_type_charged" />
+
+            <TextView
+                android:id="@+id/tv_post_price"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="30dp"
+                android:text="@string/post_register_price"
+                android:textColor="@color/black"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                app:layout_constraintLeft_toLeftOf="@+id/btn_post_type_charged"
+                app:layout_constraintTop_toBottomOf="@+id/btn_post_type_charged"
+                app:layout_constraintBottom_toTopOf="@+id/et_post_price"/>
+
+            <EditText
+                android:id="@+id/et_post_price"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:background="@drawable/post_input_background"
+                android:hint="@string/post_register_price_input"
+                android:padding="7dp"
+                android:textSize="16sp"
+                android:textStyle="normal"
+                android:inputType="number"
+                app:layout_constraintLeft_toLeftOf="@+id/tv_post_price"
+                app:layout_constraintTop_toBottomOf="@+id/tv_post_price"
+                android:maxLength="10"/>
+
+            <TextView
+                android:id="@+id/tv_post_profile_type"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="30dp"
+                android:text="@string/post_register_profile_type"
+                android:textColor="@color/black"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                app:layout_constraintLeft_toLeftOf="@+id/et_post_price"
+                app:layout_constraintTop_toBottomOf="@+id/et_post_price"
+                app:layout_constraintBottom_toTopOf="@+id/btn_post_profile_type_public"/>
+
+            <Button
+                android:id="@+id/btn_post_profile_type_public"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginTop="10dp"
+                android:text="@string/post_register_profile_type_public"
+                android:background="@drawable/sign_up_user_type_selected"
+                app:layout_constraintHorizontal_bias="0"
+                app:layout_constraintWidth_percent="0.14"
+                app:layout_constraintHeight_percent="0.03"
+                app:layout_constraintLeft_toLeftOf="@+id/tv_post_profile_type"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tv_post_profile_type" />
+
+            <Button
+                android:id="@+id/btn_post_profile_type_secret"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginStart="19dp"
+                android:layout_marginTop="10dp"
+                android:text="@string/post_register_profile_type_secret"
+                android:background="@drawable/sign_up_user_type_unselected"
+                app:layout_constraintHorizontal_bias="0"
+                app:layout_constraintWidth_percent="0.14"
+                app:layout_constraintHeight_percent="0.03"
+                app:layout_constraintLeft_toRightOf="@+id/btn_post_profile_type_public"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tv_post_profile_type"
+                app:layout_constraintBottom_toBottomOf="@+id/btn_post_profile_type_public"/>
+
+            <Button
+                android:id="@+id/btn_post_register_btn"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginTop="40dp"
+                android:layout_marginBottom="10dp"
+                android:text="@string/post_register_btn"
+                android:textColor="@color/white"
+                android:background="@drawable/btn_post_round"
+                app:layout_constraintWidth_percent="0.25"
+                app:layout_constraintHeight_percent="0.04"
+                app:layout_constraintTop_toBottomOf="@+id/btn_post_profile_type_public"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/Breaking/app/src/main/res/layout/fragment_navi_home.xml
+++ b/Breaking/app/src/main/res/layout/fragment_navi_home.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <include layout="@layout/general_toolbar_layout" />
 
@@ -13,6 +14,7 @@
         tools:context=".fragment.NaviChartFragment">
 
         <TextView
+            android:id="@+id/tv_main"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="브레이킹 메인 화면입니다."
@@ -20,6 +22,24 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+            android:id="@+id/fab_posting"
+            android:layout_width="130dp"
+            android:layout_height="40dp"
+            android:gravity="center"
+            android:theme="@style/FormButton"
+            android:text="@string/post_home_btn"
+            android:textColor="@color/breaking_color"
+            android:textStyle="bold"
+            android:textAppearance="@style/AppTextAppearance.Button"
+            android:backgroundTint="@color/main_post_button_color"
+            android:layout_marginBottom="80dp"
+            app:strokeColor="@color/breaking_drawer_color"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+           />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/Breaking/app/src/main/res/values-night/themes.xml
+++ b/Breaking/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.Breaking" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.Breaking" parent="Theme.AppCompat.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_200</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>

--- a/Breaking/app/src/main/res/values/colors.xml
+++ b/Breaking/app/src/main/res/values/colors.xml
@@ -7,7 +7,7 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="gray">#cccccc</color>
+    <color name="gray">#EBE4E4</color>
     <color name="light_gray">#dddddd</color>
     <color name="breaking_color">#014D91</color>
     <color name="breaking_drawer_color">#2D375B</color>
@@ -19,6 +19,7 @@
     <color name="sign_up_user_type_unselected_color">#B0DDFF</color>
     <color name="sign_up_user_type_text_color">#014D91</color>
     <color name="sign_up_input_error_text_color">#FF0000</color>
+    <color name="main_post_button_color">#EFF9FF</color>
     <color name="kakao_container">#FEE500</color>
     <color name="google_container">#FFFFFF</color>
 </resources>

--- a/Breaking/app/src/main/res/values/strings.xml
+++ b/Breaking/app/src/main/res/values/strings.xml
@@ -36,4 +36,23 @@
     <string name="follower">팔로워</string>
     <string name="written_post">작성 제보</string>
     <string name="setting_menu">설정</string>
+    <string name="post_home_btn">+ 제보하기</string>
+    <string name="post_register_image_video">사진/동영상 업로드</string>
+    <string name="post_register_event_time">제보 발생 시간</string>
+    <string name="post_register_location">위치</string>
+    <string name="post_register_click_location">현재 위치 찾기</string>
+    <string name="post_register_type">제보방식</string>
+    <string name="post_register_type_exclusive">단독제보</string>
+    <string name="post_register_type_charged">유료제보</string>
+    <string name="post_register_type_free">무료제보</string>
+    <string name="post_register_price">제보가격</string>
+    <string name="post_register_title">제보 내용</string>
+    <string name="post_register_content_title">제목을 입력해주세요.</string>
+    <string name="post_register_content_description">상황을 최대한 상세하게 기록해주세요.\n\n(상황, 시간, 사건 전개 과정, 경과상태 등)\n\n최대 2000자</string>
+    <string name="post_register_content_hashtag"># 해시태그를 입력하세요. (최대 8개)</string>
+    <string name="post_register_price_input">가격을 입력해주세요. (원)</string>
+    <string name="post_register_profile_type">프로필 공개 여부</string>
+    <string name="post_register_profile_type_public">공개</string>
+    <string name="post_register_profile_type_secret">비공개</string>
+    <string name="post_register_btn">제보하기</string>
 </resources>

--- a/Breaking/app/src/main/res/values/themes.xml
+++ b/Breaking/app/src/main/res/values/themes.xml
@@ -15,4 +15,16 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>
+
+    <!-- Floating Action Theme -->
+    <style name="FormButton" parent="Theme.MaterialComponents.Light.NoActionBar">
+        <item name="colorOnPrimary">@android:color/holo_red_light</item>
+        <item name="colorPrimary">@android:color/holo_orange_dark</item>
+        <item name="colorOnSurface">@android:color/holo_orange_light</item>
+    </style>
+
+    <!--To fix rendering in preview -->
+    <style name="AppTextAppearance.Button" parent="TextAppearance.MaterialComponents.Button">
+        <item name="android:textAllCaps">true</item>
+    </style>
 </resources>


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #28 

## 예상 리뷰 시간
15-min

## 추가 또는 변경사항
- 메인 피드에서 게시글 등록을 위한 제보하기 플로팅 버튼을 생성하고, 페이지와 연결하였습니다.
- 제보하기 페이지 UI 구현
  - 반응형 ConstraintLayout을 이용하여 페이지 UI를 구성하였습니다.
  - 곧 있을 기능 구현에 앞서 이미지 동영상들의 리스트가 보이도록 recyclerView를 horizontal로 배치하였습니다.
  - 각 입력 필드 값 (제보 발생 시간, 위치. 제보 내용, 제보 가격)의 inputType을 text로 지정하여 사용자의 엔터 입력을 방지했습니다.
  - 제보 가격 필드의 inputType을 number로 지정하여 숫자만 입력받도록 했습니다.
  - 제보 내용의 EditText 필드의 경우 최대 2000자로 많은 양의 내용이 들어가므로 scrollbars타입을 지정해주었습니다.
  - EditText의 스크롤과 전체 화면 스크롤에 대한 더블 스크롤 문제를 해결했습니다.
  - 제보 방식의 기본값은 '유료 제보'로, 프로필 공개 여부의 기본값은 '공개'로 설정했습니다.
  - 제보 페이지의 상단 툴 바를 생성하였습니다. 

## 스크린샷
- 메인 피드 제보하기 플로팅 버튼
<img src = "https://user-images.githubusercontent.com/31824443/180730028-88bda46c-4e15-4e0b-affc-550674ee13b1.png" width="30%" height="30%">

- 제보하기 페이지 전체 화면 캡처 (실제로는 스크롤이 이루어짐)
<img src = "https://user-images.githubusercontent.com/31824443/180726037-269ba885-d112-4019-a3a6-88fe3d9e6d36.png" width="30%" height="30%">

-  제보하기 페이지 예시
<img src = "https://user-images.githubusercontent.com/31824443/180729579-3c612ed5-167b-42f1-a495-c781560c5eca.png" width="30%" height="30%">



## 기타
- 생각지도 못했던 Floating Action Button 과 관련된 여러 삽질

  - 플로팅 버튼을 내가 원하는 색상과 테두리로 꾸미기 위해, 여느 버튼들을 커스텀하는 방식과 같게 xml 파일을 디자인하고 `background` 속성으로 지정해주면 될 줄 알았다. 그러나 `android.view.InflateException`이라는 예외와 함께 에러가 발생했는데, 나름 분석을 해본 결과 이유는 다음과 같았다. 플로팅 버튼은 뿌리가 Material 패키지인데, 정의되어 있는 레이아웃들의 테마가 AppCompat으로 지정되어 있어 발생한 문제로 보였다. 그래서 우리 앱의 테마를 모두 Material로도 바꿔봤지만 해결이 되지 않았다..이와 같은 이유로 구글링을 몇 시간동안 해봤는데 플로팅 버튼에는 다들 background속성을 쓰지 않는 추세였다. 그 대신 플로팅 버튼을 위한 `MaterialComponents`를 상속한 테마 그리고 텍스트 스타일을 각각 `android:theme`, `android:TextAppearance`에 할당해주었더니 문제는 해결되었다. 
  
  - 위와 같은 방법으로 색상 부분은 해결이 되었지만, background 속성을 쓸 수 없기 때문에 플로팅 버튼의 테두리를 설정하는 옵션에 대해서도 한참 헤맸었다. `app:strokeColor` 와 `app:strokeWidth` 로 해결했는데, 별도의 xml 없이  그 자리에서 바로 커스텀이 가능하다는 점이 편했다.

- NestedScrollView 안에서의 EditText scroll이 작동하지 않았던 문제
  - 제보 페이지에는 기본적으로 스크롤 뷰가 적용되어 있었는데, 최대 2000자의 많은 제보 내용을 적기 위해서는 EditText안에서도 따로 스크롤이 있어야 한다고 생각했다. 그런데 최상위 뷰인 스크롤 뷰에서 이미 스크롤 이벤트를 독점하고 있어서 EditText의 스크롤이 동작하지 않았다. 따라서 editText 터치 리스너 함수에서 editText를 클릭한다면 부모 스크롤 뷰에 대한 권한을 잠시 비허용하고, editText가 아닌 곳을 클릭한다면 부모의 권한을 다시 풀어주는 식으로 하여 따로 따로 동작할 수 있게 해결하였다.

- ConstraintLayout에 관한 여러가지 정리 (회고)

  - 이번에 뷰를 구성하면서 레이아웃에 대해 개인적으로 많은 공부가 되었다. 초반엔 어떻게 뷰를 구성해야 하고, 어떤 옵션을 줘야 하는지 몰랐는데 이것저것 만져보면서 옵션이 필요한 경우와 쓰임새에 대해 많은 감을 잡게 되었다. 기능도 없고 별 거 아닌 디자인 작업이었지만, 오래 걸린 만큼 배운 것이 많았고 의미 있었다.

  - 개인적으로 작업하면서 레이아웃을 좀 더 편하게 설계하기 위한 기준점이 생겼다.
    - 뷰를 구성하기 시작할 때, 최상위 의존성(다른 뷰와의 관계)을 기준으로 삼고 다음으로 추가되는 뷰들 간의 의존성을 확립해나가는 것이 편하다. 그래야 전체 레이아웃을 하나로 묶어둘 수 있고,  뷰들의 관계가 너무 제각각 정의되는 것을 막기 위함에도 있다고 생각한다. 나중에 수정하기도 편리하다.
    - 뷰들을 구성하면서 의존성을 컴포넌트별로 구분시키는 것이 중요하다. 예를 들면, 사진/동영상 업로드 영역의 뷰들과 제보 발생 시간 영역의 뷰들은 외/내부적으로 관계를 묶어두는 것이 좋다. 이는 추후에 추가될 기능에 대한 뷰까지 고려하기 때문에 재사용성 측면에서도 중요할 것 같다. (기능별로 묶여있으므로 나중에 특정 뷰만 이동시켜 공간 할당과 배치를 편하게 할 수 있다)
    - 상하 방향으로 존재하는 뷰들을 원하는 비율로 배치하기 위해 bias가 필수적이었는데, 이 때 chainStyle과 같이 쓰면 bias가 먹통이 된다. 따라서 결국 margin을 줘야 하는 조금 껄끄러운 상황이 생길 수 있기 때문에 chainStyle은 기본값인 spread로 두고 사용하면 될 것 같다. 또한 bias는 어떤 너비를 기준으로 비율을 나눌 것인지 이므로, 상황에 따라 알맞게 상하좌우를 지정해두면 될 것 같다.
    - 굳이 필요하지 않은 관계(의존성)에 대해 정의할 필요가 없다는 사실이다. 예전 ConstraintLayout에 대해 거의 몰랐을 때는 뷰의 상하좌우를 웬만하면 곡  지정해줘야 되는 줄 알았다. 내가 필요한 관계에 대해서만 확실히 정의해두는 것이 불필요한 의존성의 낭비를 줄이는 것 같다.

- 앞으로 해야 할 일&고민
  - 제보 사진이 몇 개 들어가있냐에 따라 밑에 프로그레스 바로 전체 사진 중에 몇 장 올렸는지 진행상황을 보여주는 것을 생각하고 있는데, 뷰가 좀 더러워보이진 않을까 고민이다. 어차피 왼쪽 textView로 10장 중에 몇 장 올렸는지 카운트를 해주고 있기도 해서 꼭 필요한 부분인지는 모르겠다! 사용자가 느끼기에 편하다면.. 추가하는게 맞는 것 같다.
  
  - 뷰 완성 이후 게시물 작성 요청을 보내기 위해 필요한 필드 기능 구현에 대해서는 다음과 같이 작성해나갈 예정이다.
    - 사진/동영상 업로드 : recyclerView를 통해 사진 동영상 업로드하고 리스트 보여주기, 리스트 중 원하는 사진을 삭제할 수 있게 하기
    - 제보 발생 시간 : 사용자로부터 DatePicker, TimePicker로부터 받은 값을 보여주기
    - 위치 : Map API를 시도해보거나 아니면 우선 급한 내용은 아니라고 판단하여 Dummy 값으로 채우기
    - 제보 내용&가격 : 텍스트 값 받아오는데, 해시태그 부분은 문자열 처리 필요
  
  - 추가로, 이전에 주기님으로부터 피드백 받은 BottomNavigationView도 빠른 시일 내에 리팩토링 필요해보임