### PR TITLE
feat: implement edit profile in user profile page

### DIFF
--- a/Breaking/app/src/main/AndroidManifest.xml
+++ b/Breaking/app/src/main/AndroidManifest.xml
@@ -2,12 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.dope.breaking">
-    <!-- 인터넷 사용 권한 설정 -->
-    <uses-permission android:name="android.permission.INTERNET" /> <!-- 카메라 및 저장위치를 위치 접근을 위한 권한 설정 -->
-    <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-
+    <!-- 카메라 및 저장위치를 위치 접근을 위한 권한 설정 -->
     <application
         android:name=".GlobalApplication"
         android:allowBackup="false"
@@ -20,6 +15,12 @@
         android:theme="@style/Theme.Breaking"
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
+        <activity
+            android:name=".ImageExpansionActivity"
+            android:exported="false" />
+        <activity
+            android:name=".EditProfileActivity"
+            android:exported="false" />
         <activity
             android:name=".NaviSettingActivity"
             android:exported="false" />
@@ -35,16 +36,6 @@
         <activity
             android:name=".NaviPointActivity"
             android:exported="false" /> <!-- 이미지 가져올 때, 보안상의 이유로 fileProvider 를 사용해 가져와야 함. -->
-        <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.provider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/provider_paths" />
-        </provider>
-
         <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
             android:exported="true">
@@ -78,6 +69,21 @@
         <activity
             android:name=".SignUpActivity"
             android:exported="false" />
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths" />
+        </provider>
     </application>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <uses-permission android:name="android.permission.CAMERA" />
 
 </manifest>

--- a/Breaking/app/src/main/java/com/dope/breaking/EditProfileActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/EditProfileActivity.kt
@@ -1,0 +1,254 @@
+package com.dope.breaking
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
+import android.provider.MediaStore
+import android.view.View
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import com.bumptech.glide.Glide
+import com.dope.breaking.databinding.ActivitySignUpBinding
+import com.dope.breaking.model.request.RequestUpdateUser
+import com.dope.breaking.model.response.DetailUser
+import com.dope.breaking.retrofit.RetrofitManager
+import com.dope.breaking.retrofit.RetrofitService
+import com.dope.breaking.signup.Account
+import com.dope.breaking.signup.Validation
+import com.dope.breaking.util.DialogUtil
+import com.dope.breaking.util.JwtTokenUtil
+import com.dope.breaking.util.Utils
+import com.dope.breaking.util.ValueUtil
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import okhttp3.MediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import java.io.ByteArrayOutputStream
+
+
+class EditProfileActivity : AppCompatActivity() {
+    private lateinit var binding: ActivitySignUpBinding
+    private var isRoleButtonSelected: Boolean = true // 회원 유형 버튼 flag 값
+    private lateinit var galleryActivityResult: ActivityResultLauncher<Intent> // 갤러리에서 이미지를 가져왔을 때의 처리를 위한 activityResult
+    private var filename: String = "" // 프로필 이미지 파일명
+    private var profileImgBitmap: Bitmap? = null // 프로필 이미지 비트맵 전역변수
+    private val handler = object : Handler(Looper.getMainLooper()) { // 메인 스레드에서 비트맵 변수 받아와서 할당
+        override fun handleMessage(msg: Message) {
+            profileImgBitmap = msg.data.getParcelable("Bitmap")!! // 번들에서 비트맵 객체를 받아온다.
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivitySignUpBinding.inflate(layoutInflater)
+        initView() // 초기 화면 세팅
+
+        // 프로필 이미지 버튼 클릭 시
+        binding.imgBtnProfileImage.setOnClickListener(View.OnClickListener {
+            selectGalleryIntent()
+        })
+
+        // 프로필 추가 텍스트뷰 클릭 시
+        binding.tvAddProfile.setOnClickListener(View.OnClickListener {
+            selectGalleryIntent()
+        })
+
+        // 회원 유형 - 일반인 클릭 시
+        binding.btnUserTypeDefault.setOnClickListener {
+            isRoleButtonSelected = true
+            binding.btnUserTypeOther.setBackgroundResource(R.drawable.sign_up_user_type_unselected)
+            binding.btnUserTypeDefault.setBackgroundResource(R.drawable.sign_up_user_type_selected)
+        }
+        // 회원 유형 - 언론인 클릭 시
+        binding.btnUserTypeOther.setOnClickListener {
+            isRoleButtonSelected = false
+            binding.btnUserTypeOther.setBackgroundResource(R.drawable.sign_up_user_type_selected)
+            binding.btnUserTypeDefault.setBackgroundResource(R.drawable.sign_up_user_type_unselected)
+        }
+
+        if (intent != null) {
+            val data = intent.getSerializableExtra("detail") as DetailUser
+            fillDataInView(data) // 각 View 에 가져온 데이터 채우기
+
+            galleryActivityResult =
+                registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+                    if (it.resultCode == RESULT_OK) { // 갤러리에서 이미지를 정상적으로 선택했다면
+                        val uri = it.data?.data!! // 이미지 URI
+
+                        filename = Utils.getFileNameFromURI(uri, contentResolver)!!
+                        Utils.setImageWithGlide(
+                            applicationContext,
+                            uri,
+                            binding,
+                            0,
+                            0
+                        ) // Glide 라이브러리를 사용하여 회원가입 프로필 이미지 뷰에 보여주기
+                        Utils.getBitmapWithGlide(
+                            applicationContext,
+                            uri,
+                            handler
+                        )// Glide 라이브러리를 사용하여 파일을 비트맵으로 가져와서 저장
+                    }
+                }
+
+            // 프로필 수정 완료 버튼 클릭 시
+            binding.btnUserRegister.setOnClickListener {
+                val realName = binding.etName.text.toString()
+                val email = binding.etEmail.text.toString()
+                val nickname = binding.etNickname.text.toString()
+                val phoneNumber = binding.etPhoneNumber.text.toString()
+                val statusMsg = binding.etStateMessage.text.toString()
+                val role = if (isRoleButtonSelected) "USER" else "PRESS"
+
+                val token = JwtTokenUtil(this).getTokenFromLocal() // 로컬에서 토큰 가져오기
+
+                val progressDialog = DialogUtil().ProgressDialog(this)
+                progressDialog.showDialog() // 로딩 dialog 시작
+
+                CoroutineScope(Dispatchers.Main).launch {
+                    val validation = Validation()
+                    val result =
+                        validation.startRequestSignUpValidation(
+                            nickname,
+                            phoneNumber,
+                            email,
+                            binding,
+                            "Bearer $token"
+                        ) // 닉네임, 전화번호, 이메일 검증하기
+
+                    if (result) { // 검증에 성공했다면
+                        val inputData = RequestUpdateUser(
+                            nickname,
+                            phoneNumber,
+                            email,
+                            realName,
+                            role,
+                            statusMsg,
+                        ) // 필드 객체
+
+                        val account = Account()
+                        val res = account.startRequestUpdateProfile(
+                            inputData,
+                            profileImgBitmap,
+                            filename,
+                            "Bearer ${token!!}"
+                        ) // 프로필 변경 요청
+
+                        if (progressDialog.isShowing())
+                            progressDialog.dismissDialog() // 로딩 종료
+
+                        // 변경 요청 성공 시
+                        if (res)
+                            finish() // 화면 종료
+                        else { // 요청 실패 시
+                            DialogUtil().SingleDialog(
+                                this@EditProfileActivity,
+                                "회원 정보 수정에 실패하였습니다!",
+                                "확인"
+                            ).show() // 에러 메세지 보여주기
+                        }
+                    } else { // 검증 실패 시
+                        if (progressDialog.isShowing())
+                            progressDialog.dismissDialog() // 로딩 종료
+                    }
+                }
+
+            }
+        }
+        setContentView(binding.root)
+    }
+
+    /**
+     * 초기 View 에 데이터 채워넣기
+     * @param data(DetailUser): 기존 유저 데이터
+     * @author Seunggun Sin
+     * @since 2022-07-25
+     */
+    private fun fillDataInView(data: DetailUser) {
+        binding.etName.setText(data.realName)
+        binding.etEmail.setText(data.email)
+        binding.etNickname.setText(data.nickname)
+        binding.etPhoneNumber.setText(data.phoneNumber)
+        binding.etStateMessage.setText(data.statusMsg)
+        Glide.with(this)
+            .load(ValueUtil.IMAGE_BASE_URL + data.profileImgURL)
+            .circleCrop()
+            .into(binding.imgBtnProfileImage)
+    }
+
+    /**
+     * 초기 변경되야 하는 View 세팅
+     * @author Seunggun Sin
+     * @since 2022-07-25
+     */
+    private fun initView() {
+        binding.tvAddProfile.text = "프로필 수정"
+        binding.btnUserRegister.text = "완료"
+        binding.imgBtnBack.visibility = View.VISIBLE
+        binding.imgBtnBack.setOnClickListener {
+            finish()
+        }
+    }
+
+    /**
+     * 로컬 파일 읽기 쓰기 권한 여부 체크 및 Intent 를 통한 갤러리 열기 (Tae hyun Park 이 작성한 메소드 참조)
+     * @author Seunggun Sin (Refer to Tae hyun)
+     * @since 2022-07-25
+     */
+    private fun selectGalleryIntent() {
+        // 읽기, 쓰기 권한
+        val writePermission =
+            ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        val readPermission =
+            ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)
+
+        if (writePermission == PackageManager.PERMISSION_DENIED || readPermission == PackageManager.PERMISSION_DENIED) {
+            // 권한 없다면 권한 요청
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    Manifest.permission.READ_EXTERNAL_STORAGE
+                ),
+                1
+            )
+        } else {
+            // 권한 있으면 Intent 를 통해 갤러리 Open 요청
+            DialogUtil().MultipleDialog(
+                this,
+                "       프로필 이미지 변경하기       ",
+                "기본 이미지 사용",
+                "갤러리에서 가져오기",
+                {
+                    Glide.with(this)
+                        .load(ValueUtil.getDefaultProfile(this))
+                        .circleCrop()
+                        .into(binding.imgBtnProfileImage) // 기본 이미지로 보여주기
+                    profileImgBitmap = null
+                    filename = ""
+                },
+                {
+                    // 갤러리 intent 호출
+                    val intent = Intent(Intent.ACTION_PICK)
+                    intent.setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, "image/*")
+                    galleryActivityResult.launch(intent)
+                }, true
+            ).show()
+
+        }
+    }
+
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/ImageExpansionActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/ImageExpansionActivity.kt
@@ -1,0 +1,38 @@
+package com.dope.breaking
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.widget.ImageButton
+import android.widget.ImageView
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.dope.breaking.util.ValueUtil
+
+/**
+ * 이미지 확대 클래스
+ */
+class ImageExpansionActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_image_expansion)
+
+        if (intent != null) {
+            val imgUrl = intent.getStringExtra("imgUrl") // 받아온 이미지 url 가져오기
+
+            Glide.with(this)
+                .load(ValueUtil.IMAGE_BASE_URL + imgUrl)
+                .diskCacheStrategy(DiskCacheStrategy.ALL)
+                .error(R.drawable.ic_default_profile_image)
+                .into(findViewById(R.id.full_image))
+        }
+        /*
+        이미지 클릭 시, 혹은 뒤로 가기 버튼 클릭 시 애니메이션 효과와 함께 뒤로 가기
+         */
+        findViewById<ImageView>(R.id.full_image).setOnClickListener {
+            supportFinishAfterTransition()
+        }
+        findViewById<ImageButton>(R.id.img_btn_back).setOnClickListener {
+            supportFinishAfterTransition()
+        }
+    }
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/MainActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/MainActivity.kt
@@ -3,7 +3,6 @@ package com.dope.breaking
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.util.Log
 import android.view.MenuItem
 import android.widget.Toast
 import androidx.core.view.GravityCompat
@@ -25,13 +24,10 @@ class MainActivity : AppCompatActivity() {
         mbinding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
         val intent = intent
-        if(intent != null){
-            ResponseExistLogin.baseUserInfo = intent.getSerializableExtra("userInfo") as ResponseExistLogin
+        if (intent != null) {
+            ResponseExistLogin.baseUserInfo =
+                intent.getSerializableExtra("userInfo") as ResponseExistLogin
         }
-//        setSupportActionBar(binding.toolBar) // 툴 바 설정
-//        supportActionBar!!.setDisplayHomeAsUpEnabled(true) // 왼쪽 상단 버튼 만들기
-//        supportActionBar!!.setHomeAsUpIndicator(R.drawable.ic_navi_menu_bar) // 왼쪽 상단 아이콘
-//        supportActionBar!!.setDisplayShowTitleEnabled(true) // 툴 바에 타이틀 보이게
 
         binding.bnvMain.selectedItemId = R.id.menu_breaking_home // 기본 네비게이션 화면을 메인 화면으로 설정..
         if (binding.bnvMain.selectedItemId == R.id.menu_breaking_home) // 기본 화면이 메인이라면 프레그먼트 띄워주기
@@ -49,8 +45,8 @@ class MainActivity : AppCompatActivity() {
      */
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         // 클릭된 메뉴 아이템의 아이디마다 when 구절로 클릭시 동작을 설정
-        when(item!!.itemId){
-            android.R.id.home ->{ // 툴 바 메뉴가 클릭된다면
+        when (item.itemId) {
+            android.R.id.home -> { // 툴 바 메뉴가 클릭된다면
                 binding.layoutDrawer.openDrawer(GravityCompat.START)    // 네비게이션 드로어 열기
                 return true
             }
@@ -67,9 +63,9 @@ class MainActivity : AppCompatActivity() {
     @since - 2022-07-19
      */
     override fun onBackPressed() {
-        if(binding.layoutDrawer.isDrawerOpen(GravityCompat.START)){ // 드로어가 열려있다면 닫는다.
+        if (binding.layoutDrawer.isDrawerOpen(GravityCompat.START)) { // 드로어가 열려있다면 닫는다.
             binding.layoutDrawer.closeDrawers()
-        }else{
+        } else {
             super.onBackPressed()
         }
     }
@@ -95,7 +91,7 @@ class MainActivity : AppCompatActivity() {
     @author - Tae hyun Park
     @since - 2022-07-19
      */
-    private fun bottomNavigationClicked(){
+    private fun bottomNavigationClicked() {
         binding.bnvMain.setOnItemSelectedListener { item ->
             changeFragment(
                 when (item.itemId) {
@@ -127,33 +123,33 @@ class MainActivity : AppCompatActivity() {
     @author - Tae hyun Park
     @since - 2022-07-19
      */
-    private fun NavigationDrawerClicked(){
+    private fun NavigationDrawerClicked() {
         binding.viewNavigationDrawer.setNavigationItemSelectedListener { menuItem ->
             when (menuItem.itemId) {
                 R.id.menu_drawer_point -> { // 브레이킹 포인트 버튼을 누르면
                     val intent = Intent(this, NaviPointActivity::class.java)
                     startActivity(intent)
-                    Toast.makeText(this,"Pressed Point Screen",Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this, "Pressed Point Screen", Toast.LENGTH_SHORT).show()
                 }
                 R.id.menu_drawer_bookmark -> { // 브레이킹 북마크 버튼을 누르면
                     val intent = Intent(this, NaviBookActivity::class.java)
                     startActivity(intent)
-                    Toast.makeText(this,"Pressed Bookmark Screen",Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this, "Pressed Bookmark Screen", Toast.LENGTH_SHORT).show()
                 }
                 R.id.menu_drawer_cart -> { // 브레이킹 구매한 제보 버튼을 누르면
                     val intent = Intent(this, NaviPurchaseActivity::class.java)
                     startActivity(intent)
-                    Toast.makeText(this,"Pressed Cart Screen",Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this, "Pressed Cart Screen", Toast.LENGTH_SHORT).show()
                 }
                 R.id.menu_drawer_pencil -> { // 브레이킹 프로필 편집 버튼을 누르면
                     val intent = Intent(this, NaviProfileActivity::class.java)
                     startActivity(intent)
-                    Toast.makeText(this,"Pressed Profile Screen",Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this, "Pressed Profile Screen", Toast.LENGTH_SHORT).show()
                 }
                 else -> { // 그 외는 설정 버튼을 누른 것으로 간주
                     val intent = Intent(this, NaviSettingActivity::class.java)
                     startActivity(intent)
-                    Toast.makeText(this,"Pressed Setting Screen",Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this, "Pressed Setting Screen", Toast.LENGTH_SHORT).show()
                 }
             }
             true

--- a/Breaking/app/src/main/java/com/dope/breaking/SplashActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/SplashActivity.kt
@@ -3,7 +3,7 @@ package com.dope.breaking
 import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
-import android.util.Log
+import android.os.Looper
 import androidx.appcompat.app.AppCompatActivity
 import com.dope.breaking.exception.ResponseErrorException
 import com.dope.breaking.util.JwtTokenUtil
@@ -11,26 +11,22 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
+private const val DURATION: Long = 1500
+
 class SplashActivity : AppCompatActivity() {
     private val TAG = "SplashActivity.kt"
-
-
-    companion object {
-        private const val DURATION: Long = 1500
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_splash)
 
         // 애니메이션 적용
-        Handler().postDelayed({
+        Handler(Looper.myLooper()!!).postDelayed({
             CoroutineScope(Dispatchers.Main).launch {
                 val jwtTokenUtil = JwtTokenUtil(applicationContext)
 
                 // 로컬에 Jwt 토큰이 저장되어 있다면
                 if (jwtTokenUtil.getTokenFromLocal() != null) {
-                    Log.d(TAG, "TEST1 : " + jwtTokenUtil.getTokenFromLocal())
                     // Jwt 토큰을 이용해 기본 유저 정보 요청
                     try {
                         val userData =
@@ -51,7 +47,6 @@ class SplashActivity : AppCompatActivity() {
                     }
                 } else { // 로컬에 토큰이 저장되어 있지않다면
                     // 로그인 페이지로 이동
-                    Log.d(TAG, "TEST2")
                     val intent = Intent(applicationContext, SignInActivity::class.java)
                     startActivity(intent)
                     overridePendingTransition(R.anim.fade_in, R.anim.fade_out)

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/LoadingFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/LoadingFragment.kt
@@ -13,6 +13,7 @@ import com.dope.breaking.model.response.User
 import com.dope.breaking.model.response.ResponseExistLogin
 import com.dope.breaking.retrofit.RetrofitManager
 import com.dope.breaking.retrofit.RetrofitService
+import com.dope.breaking.util.DialogUtil
 import com.dope.breaking.util.JwtTokenUtil
 import retrofit2.Call
 import retrofit2.Callback
@@ -28,6 +29,7 @@ class LoadingFragment : Fragment() {
         override fun handleMessage(msg: Message) {
             val pass = NaviUserFragment() // 유저 Fragment 객체 생성
             pass.arguments = msg.data // Fragment 의 인자 값에 받아온 유저 데이터 저장
+
             parentFragmentManager // 유저 Fragment 로 전환
                 .beginTransaction()
                 .replace(R.id.fl_board, pass)
@@ -58,11 +60,21 @@ class LoadingFragment : Fragment() {
                     val message = handler.obtainMessage()
                     message.data = bundle
                     handler.sendMessage(message)
-
+                } else {
+                    DialogUtil().SingleDialog(
+                        requireContext(),
+                        "정보를 불러오지 못했습니다. 재시도 바랍니다. ",
+                        "확인"
+                    ).show()
                 }
             }
 
             override fun onFailure(call: Call<User?>, t: Throwable) {
+                DialogUtil().SingleDialog(
+                    requireContext(),
+                    "서버에 문제가 발생하였습니다. 재시도 바랍니다.",
+                    "확인"
+                ).show()
             }
         })
         return inflater.inflate(R.layout.progress_dialog_layout, container, false)

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviUserFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviUserFragment.kt
@@ -1,43 +1,51 @@
 package com.dope.breaking.fragment
 
+import android.app.ActivityOptions
 import android.content.Intent
 import android.os.Bundle
 import android.view.*
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.fragment.app.Fragment
-import androidx.viewpager2.widget.ViewPager2
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.dope.breaking.EditProfileActivity
+import com.dope.breaking.ImageExpansionActivity
 import com.dope.breaking.NaviSettingActivity
 import com.dope.breaking.R
 import com.dope.breaking.adapter.UserViewPagerAdapter
 import com.dope.breaking.databinding.FragmentNaviUserBinding
+import com.dope.breaking.model.response.DetailUser
 import com.dope.breaking.model.response.User
-import com.dope.breaking.model.response.ResponseExistLogin
+import com.dope.breaking.retrofit.RetrofitManager
+import com.dope.breaking.retrofit.RetrofitService
+import com.dope.breaking.util.DialogUtil
+import com.dope.breaking.util.JwtTokenUtil
+import com.dope.breaking.util.ValueUtil
 import com.google.android.material.tabs.TabLayoutMediator
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
 
 class NaviUserFragment : Fragment() {
     private lateinit var binding: FragmentNaviUserBinding // 바인딩 객체
-    private val tabIconList = arrayOf(
-        R.drawable.ic_baseline_create_24,
-        R.drawable.ic_baseline_add_shopping_cart_24,
-        R.drawable.ic_baseline_bookmark_border_24
-    ) // 게시글 아이콘 리스트
-
-    companion object {
-        private const val IMAGE_BASE_URL = "https://team-dope.link:8443" // 이미지 호출을 위한 서버 base url
-    }
+    private var init = true // onCreateView 호출되는 시점을 구분하기 위해 사용
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        setHasOptionsMenu(true)
-
         val user = arguments?.getSerializable("user") as User // 로딩 Fragment 로부터 받아온 유저 객체
         binding = FragmentNaviUserBinding.inflate(inflater, container, false)
         initProfileView(user) // 초기 화면 세팅
 
+        // 프로필 이미지 클릭 시
+        binding.imgViewMyPageProfile.setOnClickListener {
+            moveToExpandedProfile(user.profileImgURL)
+        }
+        // 프로필 편집 버튼 클릭 시
+        binding.btnEditProfile.setOnClickListener {
+            getUserDetailInfo()
+        }
         return binding.root
     }
 
@@ -65,7 +73,8 @@ class NaviUserFragment : Fragment() {
         // TabLayout 과 ViewPager 를 연결
         TabLayoutMediator(tabLayout, viewPager) { tab, position ->
             // 각 탭의 아이콘 지정
-            tab.icon = AppCompatResources.getDrawable(requireActivity(), tabIconList[position])
+            tab.icon =
+                AppCompatResources.getDrawable(requireActivity(), ValueUtil.TAB_ICONS[position])
         }.attach()
 
         binding.myPageToolBar.setOnMenuItemClickListener {
@@ -79,13 +88,94 @@ class NaviUserFragment : Fragment() {
         }
 
         Glide.with(this) // 이미지 보여주기
-            .load(IMAGE_BASE_URL + ResponseExistLogin.baseUserInfo!!.profileImgUrl) // url에 대한 이미지 호출
+            .load(ValueUtil.IMAGE_BASE_URL + userData.profileImgURL) // url 에 대한 이미지 호출
             .circleCrop() // 이미지 원형으로 만들기
             .diskCacheStrategy(DiskCacheStrategy.ALL) // 이미지 캐싱
-            .into(binding.imgvMyPageProfile)
+            .error(R.drawable.ic_default_profile_image) // url 호출 에러 시 기본 이미지
+            .into(binding.imgViewMyPageProfile)
+    }
+
+    /**
+     * 프로필 편집 버튼 클릭 시 프로필 편집 페이지로 이동하는 함수
+     * @param detailUserData(DetailUser): 프로필 편집을 위한 기존 유저의 데이터 클래스
+     */
+    private fun moveToEditProfile(detailUserData: DetailUser) {
+        init = false // 다시 이 페이지로 돌아와서 onStart 생명주기를 사용하기 위해 flag 값 전환
+        val intent = Intent(requireActivity(), EditProfileActivity::class.java)
+        intent.putExtra("detail", detailUserData)
+        startActivity(intent)
+    }
+
+    /**
+     * 프로필 이미지 클릭 시, 이미지 확대 페이지로 이동 (Transition Animation 적용)
+     * @param url(String): 현재 프로필 페이지에 보여지고 있는 이미지에 대한 url
+     * @author Seunggun Sin
+     * @since 2022-07-25
+     */
+    private fun moveToExpandedProfile(url: String) {
+        val intent = Intent(requireActivity(), ImageExpansionActivity::class.java)
+        intent.putExtra("imgUrl", url)
+        val opt = ActivityOptions.makeSceneTransitionAnimation( // Transition Animation
+            requireActivity(),
+            binding.imgViewMyPageProfile,
+            "imgTrans" // 지정된 transition 이름에 해당하는 View 를 기준
+        )
+        startActivity(intent, opt.toBundle())
+    }
+
+    /**
+     * 현재 로그인한 유저의 Jwt 토큰을 이용하여 프로필 편집에 필요한 기존 유저 데이터를 요청하는 함수
+     * 동시에 요청 성공 시 프로필 편집 페이지로 이동한다.
+     * @author Seunggun Sin
+     * @since 2022-07-25
+     */
+    private fun getUserDetailInfo() {
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+        val token = JwtTokenUtil(requireActivity()).getTokenFromLocal() // 로컬에 저장된 토큰 가져오기
+        if (token != null)
+        // 기존 유저 데이터 요청
+            service.requestDetailUserInfo("Bearer $token").enqueue(object : Callback<DetailUser?> {
+                override fun onResponse(call: Call<DetailUser?>, response: Response<DetailUser?>) {
+                    if (response.isSuccessful) {
+                        val body = response.body()
+                        if (body != null) // 성공하고 정상적인 값이 존재하면
+                            moveToEditProfile(body) // 프로필 편집 페이지로 이동
+                    } else {
+                        DialogUtil().SingleDialog(
+                            requireContext(),
+                            "정보를 불러오지 못했습니다. 재시도 바랍니다. ",
+                            "확인"
+                        ).show()
+                    }
+                }
+
+                override fun onFailure(call: Call<DetailUser?>, t: Throwable) {
+                    DialogUtil().SingleDialog(
+                        requireContext(),
+                        "서버에 문제가 발생하였습니다. 재시도 바랍니다.",
+                        "확인"
+                    ).show()
+                }
+            })
+        else
+            DialogUtil().SingleDialog(requireContext(), "사용자를 식별할 수 없습니다! 앱을 재실행바랍니다.", "확인").show()
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         activity?.menuInflater?.inflate(R.menu.title_menu, menu)
+    }
+
+    /**
+     * onStart Lifecycle - 이 Fragment 로부터 벗어나고 다시 돌아왔을 때 프로필 페이지 갱신을 위함
+     */
+    override fun onStart() {
+        super.onStart()
+        if (!init) { // onCreateView() 가 이미 호출된 적이 있을 때 & 다시 이 Fragment 로 돌아왔을 때
+            // 유저 Fragment 를 리프레시 하기 위해 LoadingFragment 로 전환
+            parentFragmentManager
+                .beginTransaction()
+                .replace(R.id.fl_board, LoadingFragment())
+                .commit()
+        }
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/model/request/RequestUpdateUser.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/request/RequestUpdateUser.kt
@@ -1,0 +1,40 @@
+package com.dope.breaking.model.request
+
+import org.json.JSONObject
+
+data class RequestUpdateUser(
+    val nickname: String,
+    val phoneNumber: String,
+    val email: String,
+    val realName: String,
+    val role: String,
+    val statusMsg: String,
+){
+    /**
+     * 모든 필드 값들을 json 데이터로 변환해주는 메소드
+     * @return JSONObject: 모든 필드들을 json 으로 변환한 객체 반환
+     * @author Seunggun Sin
+     * @since 2022-07-25
+     */
+    fun convertFieldsToJson(): JSONObject {
+        val jsonObject = JSONObject()
+        jsonObject.put("nickname", nickname)
+        jsonObject.put("phoneNumber", phoneNumber)
+        jsonObject.put("email", email)
+        jsonObject.put("realName", realName)
+        jsonObject.put("role", role)
+        jsonObject.put("statusMsg", statusMsg)
+        return jsonObject
+    }
+
+    /**
+     * json 형태의 데이터를 json string 형태로 변환해주는 메소드
+     * @return String: 필드 값들을 json 형태로 변환 후 뒤, 문자열로 변환한 값 반환
+     * @author Seunggun Sin
+     * @since 2022-07-25
+     */
+    fun convertJsonToString(): String {
+        val json = convertFieldsToJson() // json 으로 변환
+        return json.toString() // json 을 문자열로 변환
+    }
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/model/response/DetailUser.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/response/DetailUser.kt
@@ -1,0 +1,14 @@
+package com.dope.breaking.model.response
+
+import com.google.gson.annotations.SerializedName
+import java.io.Serializable
+
+data class DetailUser(
+    @SerializedName("nickname") val nickname: String,
+    @SerializedName("phoneNumber") val phoneNumber: String,
+    @SerializedName("email") val email: String,
+    @SerializedName("realName") val realName: String,
+    @SerializedName("role") val role: String,
+    @SerializedName("statusMsg") val statusMsg: String,
+    @SerializedName("profileImgURL") val profileImgURL: String,
+): Serializable

--- a/Breaking/app/src/main/java/com/dope/breaking/oauth/GoogleLogin.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/oauth/GoogleLogin.kt
@@ -12,6 +12,7 @@ import com.dope.breaking.model.response.ResponseLogin
 import com.dope.breaking.retrofit.RetrofitManager
 import com.dope.breaking.retrofit.RetrofitService
 import com.dope.breaking.util.JwtTokenUtil
+import com.dope.breaking.util.ValueUtil
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
@@ -24,7 +25,6 @@ import org.json.JSONObject
 import retrofit2.Response
 
 class GoogleLogin(private val context: Context) {
-    private val jwtHeaderKey = "authorization" // JWT 토큰 검증을 위한 헤더 키 값
     var responseBody: Any? = null // 구글 로그인 프로세스 가운데 얻는 response body 값
 
     // 구글 로그인 시 여러가지 옵션에 대한 객체
@@ -71,7 +71,11 @@ class GoogleLogin(private val context: Context) {
             if (validationResponse?.code() in 200..299) {
                 // 토큰이 있으면 true, 없으면 false 리턴
                 val jwtTokenUtil = JwtTokenUtil(context)
-                return if (jwtTokenUtil.hasJwtToken(jwtHeaderKey, validationResponse!!.headers())) {
+                return if (jwtTokenUtil.hasJwtToken(
+                        ValueUtil.JWT_HEADER_KEY,
+                        validationResponse!!.headers()
+                    )
+                ) {
                     // 로컬에 저장된 토큰이 없다면 저장하기
                     if (jwtTokenUtil.getTokenFromLocal() == null) {
                         jwtTokenUtil.setToken(jwtTokenUtil.getTokenFromResponse(validationResponse.headers())!!)

--- a/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
@@ -1,12 +1,9 @@
 package com.dope.breaking.retrofit
 
-import com.dope.breaking.model.response.User
 import com.dope.breaking.model.request.RequestGoogleAccessToken
 import com.dope.breaking.model.request.RequestGoogleToken
 import com.dope.breaking.model.request.RequestKakaoToken
-import com.dope.breaking.model.response.ResponseExistLogin
-import com.dope.breaking.model.response.ResponseGoogleAccessToken
-import com.dope.breaking.model.response.ResponseLogin
+import com.dope.breaking.model.response.*
 import com.google.gson.JsonElement
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
@@ -32,7 +29,10 @@ interface RetrofitService {
      * @author - Tae hyun Park
      */
     @GET("/oauth2/sign-up/validate-phone-number/{phoneNumber}")
-    suspend fun requestValidationPhoneNum(@Path("phoneNumber") phoneNumber: String): Response<Unit>
+    suspend fun requestValidationPhoneNum(
+        @Header("authorization") token: String,
+        @Path("phoneNumber") phoneNumber: String
+    ): Response<Unit>
 
     /**
      * 회원가입 시 닉네임 검증 요청 메소드
@@ -41,7 +41,10 @@ interface RetrofitService {
      * @author - Tae hyun Park
      */
     @GET("/oauth2/sign-up/validate-nickname/{nickName}")
-    suspend fun requestValidationNickName(@Path("nickName") nickName: String): Response<Unit>
+    suspend fun requestValidationNickName(
+        @Header("authorization") token: String,
+        @Path("nickName") nickName: String
+    ): Response<Unit>
 
     /**
      * 회원가입 시 이메일 검증 요청 메소드
@@ -50,7 +53,10 @@ interface RetrofitService {
      * @author - Tae hyun Park
      */
     @GET("/oauth2/sign-up/validate-email/{email}")
-    suspend fun requestValidationEmail(@Path("email") email: String): Response<Unit>
+    suspend fun requestValidationEmail(
+        @Header("authorization") token: String,
+        @Path("email") email: String
+    ): Response<Unit>
 
     /**
      * 구글 로그인 토큰 검증 요청 메소드
@@ -81,7 +87,7 @@ interface RetrofitService {
      * @response ResponseJwtUserInfo (기본 유저 정보에 대한 DTO 클래스)
      * @author Seunggun Sin
      */
-    @POST("oauth2/validate-jwt")
+    @GET("oauth2/validate-jwt")
     suspend fun requestValidationJwt(@Header("Authorization") token: String): Response<ResponseExistLogin>
 
     /**
@@ -96,6 +102,30 @@ interface RetrofitService {
         @Path("userId") userId: Long,
         @Header("authorization") token: String
     ): Call<User>
+
+    /**
+     * 유저 정보 변경을 위한 본인의 유저 데이터를 가져오는 요청
+     * @header authorization: 요청하는 유저의 Jwt 토큰 값
+     * @response DetailUser: 기존 유저의 정보 DTO 객체
+     * @author Seunggun Sin
+     */
+    @GET("profile/detail")
+    fun requestDetailUserInfo(@Header("authorization") token: String): Call<DetailUser>
+
+    /**
+     * Multipart 유저 프로필 변경 요청
+     * @header authorization: 요청하는 유저의 Jwt 토큰 값
+     * @param image(MultipartBody.Part?): 이미지 데이터 (null 값 보낼 시 기본 이미지로 변경)
+     * @param data(RequestBody): 요청 데이터 필드 값
+     * @response x
+     */
+    @Multipart
+    @PUT("profile")
+    suspend fun requestUpdateUserInfo(
+        @Header("authorization") token: String,
+        @Part image: MultipartBody.Part?,
+        @Part("updateRequest") data: RequestBody
+    ): Response<Unit>
 
     /**
      * OAuth2 구글 API 서버로부터 엑세스 토큰 요청 메소드

--- a/Breaking/app/src/main/java/com/dope/breaking/signup/Account.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/signup/Account.kt
@@ -3,8 +3,10 @@ package com.dope.breaking.signup
 import android.graphics.Bitmap
 import com.dope.breaking.exception.ResponseErrorException
 import com.dope.breaking.model.request.RequestSignUp
+import com.dope.breaking.model.request.RequestUpdateUser
 import com.dope.breaking.retrofit.RetrofitManager
 import com.dope.breaking.retrofit.RetrofitService
+import com.dope.breaking.util.ValueUtil
 import okhttp3.Headers
 import okhttp3.MediaType
 import okhttp3.MultipartBody
@@ -12,8 +14,7 @@ import okhttp3.RequestBody
 import java.io.ByteArrayOutputStream
 import kotlin.jvm.Throws
 
-class Register {
-    private val multiPartFileName = "profileImg" // multi part 요청에 대한 key 이름
+class Account {
 
     /**
      * input 으로 받아온 회원가입 정보를 바탕으로 Request Body 생성 및 회원가입 요청하는 메소드
@@ -39,7 +40,11 @@ class Register {
             RequestBody.create(MediaType.parse("image/*"), convertBitmapToByte(imageData))
         // 이미지에 대한 RequestBody 를 바탕으로 Multi form 데이터 생성
         val imgFile =
-            MultipartBody.Part.createFormData(multiPartFileName, imageName, imageRequestBody)
+            MultipartBody.Part.createFormData(
+                ValueUtil.MULTIPART_PROFILE_KEY,
+                imageName,
+                imageRequestBody
+            )
         // 나머지 필드에 대한 RequestBody 생성 (text/plain)
         val data =
             RequestBody.create(MediaType.parse("text/plain"), inputData.convertJsonToString())
@@ -52,6 +57,44 @@ class Register {
         } else { // 실패했다면
             // 예외 던지기
             throw ResponseErrorException("요청에 실패하였습니다. error: ${response.errorBody()?.string()}")
+        }
+    }
+
+    /**
+     * 유저 프로필 변경하는 요청
+     * @param inputData(RequestUpdateUser): 기존 유저 데이터에 대한 필드 값에 대한 DTO
+     * @param imageData(Bitmap?): 이미지 bitmap 데이터 (null 값 허용)
+     * @param imageFileName(String): 이미지 파일 이름
+     * @param token(String): 요청하는 유저의 Jwt 토큰
+     * @return Boolean: 요청 성공 시 true, 실패 시 false
+     * @author Seunggun Sin
+     * @since 2022-07-25
+     */
+    suspend fun startRequestUpdateProfile(
+        inputData: RequestUpdateUser,
+        imageData: Bitmap?,
+        imageFileName: String,
+        token: String
+    ): Boolean {
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+
+        val data =
+            RequestBody.create(MediaType.parse("text/plain"), inputData.convertJsonToString())
+        return if (imageData != null) { // 이미지 데이터가 있을 경우
+            // 이미지 데이터에 대해 form data 생성
+            val imageRequestBody =
+                RequestBody.create(MediaType.parse("image/*"), convertBitmapToByte(imageData))
+            val imgFile =
+                MultipartBody.Part.createFormData(
+                    ValueUtil.MULTIPART_PROFILE_KEY,
+                    imageFileName,
+                    imageRequestBody
+                )
+            val response = service.requestUpdateUserInfo(token, imgFile, data)
+            response.code() in 200..299 // 요청 성공 시 true 리턴
+        } else { // 이미지 데이터가 없을 경우
+            val response = service.requestUpdateUserInfo(token, null, data)
+            response.code() in 200..299 // 요청 성공 시 true 리턴
         }
     }
 

--- a/Breaking/app/src/main/java/com/dope/breaking/signup/Validation.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/signup/Validation.kt
@@ -11,7 +11,7 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import retrofit2.Response
 
-class Validation() {
+class Validation {
     private val TAG = "Validation.kt" // Log Tag
     private var jsonObject = JsonObject() // JSONObject
 
@@ -25,20 +25,26 @@ class Validation() {
      **/
     @SuppressLint("ResourceAsColor")
     suspend fun startRequestSignUpValidation(
-        nickName:String,
+        nickName: String,
         phoneNumber: String,
         email: String,
-        binding: ActivitySignUpBinding
-    ): Boolean{
-        var service = RetrofitManager.retrofit.create(RetrofitService::class.java) // 레트로핏 서비스 객체
-        val resNickname = service.requestValidationNickName(nickName) // 닉네임 유효성 요청의 응답 response 객체
-        val resPhoneNum = service.requestValidationPhoneNum(phoneNumber)  // 전화번호 유효성 요청의 응답 response 객체
-        val resEmail = service.requestValidationEmail(email) // 이메일 유효성 요청의 응답 response 객체
+        binding: ActivitySignUpBinding,
+        headerToken: String = ""
+    ): Boolean {
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java) // 레트로핏 서비스 객체
+        val resNickname =
+            service.requestValidationNickName(headerToken, nickName) // 닉네임 유효성 요청의 응답 response 객체
+        val resPhoneNum = service.requestValidationPhoneNum(
+            headerToken,
+            phoneNumber
+        )  // 전화번호 유효성 요청의 응답 response 객체
+        val resEmail =
+            service.requestValidationEmail(headerToken, email) // 이메일 유효성 요청의 응답 response 객체
 
-        if(binding.etName.text.toString().isBlank()){ // 이름 필드 비워져 있는지 확인
+        if (binding.etName.text.toString().isBlank()) { // 이름 필드 비워져 있는지 확인
             binding.tvNameError.setText(R.string.sign_up_none_name)
             binding.tvNameError.visibility = View.VISIBLE
-        }else
+        } else
             binding.tvNameError.visibility = View.GONE
 
         nickNameValidation(resNickname, binding) // 닉네임 검증 결과에 대한 처리
@@ -48,7 +54,8 @@ class Validation() {
         emailValidation(resEmail, binding) // 이메일 검증 결과에 대한 처리
 
         // 세 가지 검증 요청의 성공과 이름 필드까지 입력했다면 true, 하나라도 올바르지 않다면 false 를 리턴
-        return binding.etName.text.toString().isNotBlank() && resNickname.code() == 200 && resPhoneNum.code() == 200 && resEmail.code() == 200
+        return binding.etName.text.toString()
+            .isNotBlank() && resNickname.code() == 200 && resPhoneNum.code() == 200 && resEmail.code() == 200
     }
 
     /**
@@ -58,24 +65,28 @@ class Validation() {
     @author - Tae hyun Park
     @since - 2022-07-13 | 2022-07-21
      **/
-    private fun nickNameValidation(resNickname: Response<Unit>, binding: ActivitySignUpBinding){
-        if (resNickname.code() == 200){
+    private fun nickNameValidation(resNickname: Response<Unit>, binding: ActivitySignUpBinding) {
+        if (resNickname.code() == 200) {
             Log.d(TAG, "닉네임 검증 성공")
             binding.tvNicknameError.visibility = View.GONE
-        }else{ // 올바르지 않은 응답 코드가 온 경우
+        } else { // 올바르지 않은 응답 코드가 온 경우
             var errorString = resNickname.errorBody()?.string()!!
             jsonObject = JsonParser.parseString(errorString).asJsonObject
-            Log.d(TAG, "닉네임 검증 실패 : "+errorString)
-            if(binding.etNickname.text.toString().isNotBlank()){ // 닉네임을 입력했는데
-                if(jsonObject.get("code").toString().replace("\"","") == "BSE410"){
-                    binding.tvNicknameError.setText(jsonObject.get("message").toString().replace("\"","")) // 형식 에러인 경우
+            Log.d(TAG, "닉네임 검증 실패 : " + errorString)
+            if (binding.etNickname.text.toString().isNotBlank()) { // 닉네임을 입력했는데
+                if (jsonObject.get("code").toString().replace("\"", "") == "BSE410") {
+                    binding.tvNicknameError.setText(
+                        jsonObject.get("message").toString().replace("\"", "")
+                    ) // 형식 에러인 경우
                     binding.tvNicknameError.visibility = View.VISIBLE
-                }else if(jsonObject.get("code").toString().replace("\"","") == "BSE413"){
-                    binding.tvNicknameError.setText(jsonObject.get("message").toString().replace("\"","")) // 중복 에러인 경우
+                } else if (jsonObject.get("code").toString().replace("\"", "") == "BSE413") {
+                    binding.tvNicknameError.setText(
+                        jsonObject.get("message").toString().replace("\"", "")
+                    ) // 중복 에러인 경우
                     binding.tvNicknameError.visibility = View.VISIBLE
                 }
                 // 이외의 케이스에 대해 예외를 만들거나, 추가적인 처리 필요
-            }else{ // 닉네임 필드가 비워져 있다면
+            } else { // 닉네임 필드가 비워져 있다면
                 binding.tvNicknameError.setText(R.string.sign_up_none_nickname_text)
                 binding.tvNicknameError.visibility = View.VISIBLE
             }
@@ -89,24 +100,28 @@ class Validation() {
     @author - Tae hyun Park
     @since - 2022-07-13 | 2022-07-21
      **/
-    private fun phoneNumberValidation(resPhoneNum: Response<Unit>, binding: ActivitySignUpBinding){
-        if (resPhoneNum.code() == 200){
+    private fun phoneNumberValidation(resPhoneNum: Response<Unit>, binding: ActivitySignUpBinding) {
+        if (resPhoneNum.code() == 200) {
             Log.d(TAG, "전화번호 검증 성공")
             binding.tvPhoneNumberError.visibility = View.GONE
-        }else{ // 올바르지 않은 응답 코드가 온 경우
-            if (binding.etPhoneNumber.text.toString().isNotBlank()){ // 전화번호를 입력했는데
-                var errorString = resPhoneNum.errorBody()?.string()!!
+        } else { // 올바르지 않은 응답 코드가 온 경우
+            if (binding.etPhoneNumber.text.toString().isNotBlank()) { // 전화번호를 입력했는데
+                val errorString = resPhoneNum.errorBody()?.string()!!
                 jsonObject = JsonParser.parseString(errorString).asJsonObject
-                Log.d(TAG, "전화번호 검증 실패 : "+errorString)
-                if(jsonObject.get("code").toString().replace("\"","") == "BSE411"){
-                    binding.tvPhoneNumberError.setText(jsonObject.get("message").toString().replace("\"",""))    // 형식 에러인 경우
+                Log.d(TAG, "전화번호 검증 실패 : " + errorString)
+                if (jsonObject.get("code").toString().replace("\"", "") == "BSE411") {
+                    binding.tvPhoneNumberError.setText(
+                        jsonObject.get("message").toString().replace("\"", "")
+                    )    // 형식 에러인 경우
                     binding.tvPhoneNumberError.visibility = View.VISIBLE
-                }else{
-                    binding.tvPhoneNumberError.setText(jsonObject.get("message").toString().replace("\"",""))       // 중복 에러인 경우 (BSE414)
+                } else {
+                    binding.tvPhoneNumberError.setText(
+                        jsonObject.get("message").toString().replace("\"", "")
+                    )       // 중복 에러인 경우 (BSE414)
                     binding.tvPhoneNumberError.visibility = View.VISIBLE
                 }
                 // 이외의 케이스에 대해 예외를 만들거나, 추가적인 처리 필요
-            }else{ // 전화번호 필드가 비워져 있다면
+            } else { // 전화번호 필드가 비워져 있다면
                 binding.tvPhoneNumberError.setText(R.string.sign_up_none_phone_number_text)
                 binding.tvPhoneNumberError.visibility = View.VISIBLE
             }
@@ -120,24 +135,28 @@ class Validation() {
     @author - Tae hyun Park
     @since - 2022-07-13 | 2022-07-21
      **/
-    private fun emailValidation(resEmail: Response<Unit>, binding: ActivitySignUpBinding){
-        if (resEmail.code() == 200){
+    private fun emailValidation(resEmail: Response<Unit>, binding: ActivitySignUpBinding) {
+        if (resEmail.code() == 200) {
             Log.d(TAG, "이메일 검증 성공")
             binding.tvEmailError.visibility = View.GONE
-        }else{
-            if (binding.etEmail.text.toString().isNotBlank()){ // 이메일을 입력했는데
-                var errorString = resEmail.errorBody()?.string()
+        } else {
+            if (binding.etEmail.text.toString().isNotBlank()) { // 이메일을 입력했는데
+                val errorString = resEmail.errorBody()?.string()
                 jsonObject = JsonParser.parseString(errorString).asJsonObject
-                Log.d(TAG, "이메일 검증 실패 : "+errorString)     // 중복과 형식 2가지 케이스
-                if(jsonObject.get("code").toString().replace("\"","") == "BSE412"){
-                    binding.tvEmailError.setText(jsonObject.get("message").toString().replace("\"",""))    // 형식 에러인 경우
+                Log.d(TAG, "이메일 검증 실패 : " + errorString)     // 중복과 형식 2가지 케이스
+                if (jsonObject.get("code").toString().replace("\"", "") == "BSE412") {
+                    binding.tvEmailError.setText(
+                        jsonObject.get("message").toString().replace("\"", "")
+                    )    // 형식 에러인 경우
                     binding.tvEmailError.visibility = View.VISIBLE
-                }else{
-                    binding.tvEmailError.setText(jsonObject.get("message").toString().replace("\"",""))       // 중복 에러인 경우 (BSE415)
+                } else {
+                    binding.tvEmailError.setText(
+                        jsonObject.get("message").toString().replace("\"", "")
+                    )       // 중복 에러인 경우 (BSE415)
                     binding.tvEmailError.visibility = View.VISIBLE
                 }
                 // 이외의 케이스에 대해 예외를 만들거나, 추가적인 처리 필요
-            }else{ // 이메일 필드가 비워져 있다면
+            } else { // 이메일 필드가 비워져 있다면
                 binding.tvEmailError.setText(R.string.sign_up_none_email_text)
                 binding.tvEmailError.visibility = View.VISIBLE
             }

--- a/Breaking/app/src/main/java/com/dope/breaking/util/DialogUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/DialogUtil.kt
@@ -28,7 +28,7 @@ class DialogUtil {
         context: Context,
         private val content: String,
         private val buttonText: String,
-        private val event: () -> Unit
+        private val event: () -> Unit = { }
     ) : Dialog(context) {
 
         override fun onCreate(savedInstanceState: Bundle?) {
@@ -52,14 +52,45 @@ class DialogUtil {
 
     /**
      * 텍스트 컨텐츠 하나와 두개의 버튼으로 이루어진 Dialog
+     * @param context(Context): 이 Dialog 가 보여지고자 하는 컨텍스트
+     * @param leftText(String): 왼쪽 버튼 텍스트
+     * @param rightText(String): 오른쪽 버튼 텍스트
+     * @param leftEvent(()-> Unit)): 왼쪽 버튼 클릭 시 실행할 함수
+     * @param rightEvent(()-> Unit)): 오른쪽 버튼 클릭 시 실행할 함수
+     * @param allowCancel(Boolean): 외부 영역 클릭 시 종료 허용 여부
      */
-    inner class MultipleDialog(context: Context) : Dialog(context) {
+    inner class MultipleDialog(
+        context: Context,
+        private val content: String,
+        private val leftText: String,
+        private val rightText: String,
+        private val leftEvent: () -> Unit = {},
+        private val rightEvent: () -> Unit = {},
+        private val allowCancel: Boolean = false
+    ) : Dialog(context) {
 
         override fun onCreate(savedInstanceState: Bundle?) {
             super.onCreate(savedInstanceState)
             setContentView(R.layout.custom_dialog_multiple_button)
             window!!.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-            setCanceledOnTouchOutside(false)
+            setCanceledOnTouchOutside(allowCancel)
+
+            val textView = findViewById<TextView>(R.id.tv_dialog_content)
+            textView.text = content
+
+            val leftButton = findViewById<Button>(R.id.btn_dialog_multi_left)
+            leftButton.text = leftText
+            leftButton.setOnClickListener {
+                leftEvent()
+                dismiss()
+            }
+
+            val rightButton = findViewById<Button>(R.id.btn_dialog_multi_right)
+            rightButton.text = rightText
+            rightButton.setOnClickListener {
+                rightEvent()
+                dismiss()
+            }
         }
     }
 

--- a/Breaking/app/src/main/java/com/dope/breaking/util/JwtTokenUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/JwtTokenUtil.kt
@@ -15,7 +15,6 @@ import kotlin.jvm.Throws
  */
 class JwtTokenUtil(context: Context) {
     private val fileName = "jwt" // SharedPreferences 의 파일 이름
-    private val keyName = "authorization" // 헤더 키 값
     private val prefUtil = PreferenceUtil(context, fileName) // SharedPreferences Util 객체
 
     /**
@@ -66,7 +65,7 @@ class JwtTokenUtil(context: Context) {
      * @since 2022-07-09
      */
     fun getTokenFromResponse(headers: Headers): String? {
-        return headers[keyName]
+        return headers[ValueUtil.JWT_HEADER_KEY]
     }
 
     /**

--- a/Breaking/app/src/main/java/com/dope/breaking/util/ValueUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/ValueUtil.kt
@@ -1,0 +1,28 @@
+package com.dope.breaking.util
+
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.graphics.drawable.toBitmap
+import com.dope.breaking.R
+
+/**
+ * 여러군데에서 사용되는 hard coded 값들을 저장하는 클래스
+ */
+class ValueUtil {
+    companion object {
+        const val IMAGE_BASE_URL = "https://team-dope.link:8443" // 이미지 호출을 위한 서버 base url
+        const val MULTIPART_PROFILE_KEY = "profileImg" // multi part 요청에 대한 key 이름
+        const val JWT_HEADER_KEY = "authorization" // JWT 토큰 검증을 위한 헤더 키 값
+
+        val TAB_ICONS = arrayOf(
+            R.drawable.ic_baseline_create_24,
+            R.drawable.ic_baseline_add_shopping_cart_24,
+            R.drawable.ic_baseline_bookmark_border_24
+        ) // 게시글 아이콘 리스트
+
+        fun getDefaultProfile(context: Context): Bitmap =
+            AppCompatResources.getDrawable(context, R.drawable.ic_default_profile_image)
+                ?.toBitmap()!!
+    }
+}

--- a/Breaking/app/src/main/res/drawable/ic_baseline_arrow_back_black_24.xml
+++ b/Breaking/app/src/main/res/drawable/ic_baseline_arrow_back_black_24.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/black" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/Breaking/app/src/main/res/drawable/ic_baseline_arrow_back_white_24.xml
+++ b/Breaking/app/src/main/res/drawable/ic_baseline_arrow_back_white_24.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#FFFFFF" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/Breaking/app/src/main/res/layout/activity_image_expansion.xml
+++ b/Breaking/app/src/main/res/layout/activity_image_expansion.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/black"
+    tools:context=".ImageExpansionActivity">
+
+    <ImageButton
+        android:id="@+id/img_btn_back"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="15dp"
+        android:background="@drawable/ic_baseline_arrow_back_white_24"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/full_image"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:transitionName="imgTrans"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Breaking/app/src/main/res/layout/activity_sign_up.xml
+++ b/Breaking/app/src/main/res/layout/activity_sign_up.xml
@@ -1,289 +1,301 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fillViewport="true"
-    >
-<androidx.constraintlayout.widget.ConstraintLayout
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".SignUpActivity">
+    android:fillViewport="true">
 
-    <Button
-        android:id="@+id/btn_user_type_default"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="5dp"
-        android:background="@drawable/sign_up_user_type_selected"
-        android:padding="5dp"
-        android:text="@string/sign_up_user_type_default_btn"
-        android:textColor="@color/sign_up_user_type_text_color"
-        android:textSize="16dp"
-        app:layout_constraintHeight_percent="0.045"
-        app:layout_constraintLeft_toLeftOf="@id/tv_user_type"
-        app:layout_constraintTop_toBottomOf="@id/tv_user_type"
-        app:layout_constraintWidth_percent="0.17" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".SignUpActivity">
 
-    <Button
-        android:id="@+id/btn_user_type_other"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginStart="19dp"
-        android:layout_marginTop="5dp"
-        android:background="@drawable/sign_up_user_type_unselected"
-        android:padding="5dp"
-        android:text="@string/sign_up_user_type_other_btn"
-        android:textColor="@color/sign_up_user_type_text_color"
-        android:textSize="16dp"
-        app:layout_constraintHeight_percent="0.045"
-        app:layout_constraintLeft_toRightOf="@id/btn_user_type_default"
-        app:layout_constraintTop_toBottomOf="@id/tv_user_type"
-        app:layout_constraintWidth_percent="0.17" />
+        <Button
+            android:id="@+id/btn_user_type_default"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="5dp"
+            android:background="@drawable/sign_up_user_type_selected"
+            android:padding="5dp"
+            android:text="@string/sign_up_user_type_default_btn"
+            android:textColor="@color/sign_up_user_type_text_color"
+            android:textSize="16dp"
+            app:layout_constraintHeight_percent="0.045"
+            app:layout_constraintLeft_toLeftOf="@id/tv_user_type"
+            app:layout_constraintTop_toBottomOf="@id/tv_user_type"
+            app:layout_constraintWidth_percent="0.17" />
 
-    <Button
-        android:id="@+id/btn_user_register"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:background="@drawable/sign_up_button_background"
-        android:text="@string/sign_up"
-        android:textColor="@color/white"
-        android:layout_marginTop="50dp"
-        android:layout_marginBottom="20dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHeight_percent="0.045"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/btn_user_type_default"
-        app:layout_constraintVertical_bias="0.8"
-        app:layout_constraintWidth_percent="0.3" />
+        <Button
+            android:id="@+id/btn_user_type_other"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="18dp"
+            android:layout_marginTop="5dp"
+            android:background="@drawable/sign_up_user_type_unselected"
+            android:padding="5dp"
+            android:text="@string/sign_up_user_type_other_btn"
+            android:textColor="@color/sign_up_user_type_text_color"
+            android:textSize="16dp"
+            app:layout_constraintHeight_percent="0.045"
+            app:layout_constraintLeft_toRightOf="@id/btn_user_type_default"
+            app:layout_constraintTop_toBottomOf="@id/tv_user_type"
+            app:layout_constraintWidth_percent="0.17" />
 
-    <EditText
-        android:id="@+id/et_nickname"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
-        android:background="@drawable/sign_up_input_background"
-        android:hint="@string/sign_up_nickname_text"
-        android:padding="8dp"
-        android:textColorHint="@color/sign_up_input_hint_text_color"
-        android:textSize="17dp"
-        android:inputType="text"
-        android:maxLength="10"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_nickname"
-        app:layout_constraintWidth_percent="0.8" />
+        <Button
+            android:id="@+id/btn_user_register"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="40dp"
+            android:layout_marginBottom="15dp"
+            android:background="@drawable/sign_up_button_background"
+            android:text="@string/sign_up"
+            android:textColor="@color/white"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHeight_percent="0.045"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btn_user_type_default"
+            app:layout_constraintVertical_bias="0.8"
+            app:layout_constraintWidth_percent="0.3" />
 
-    <EditText
-        android:id="@+id/et_name"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
-        android:background="@drawable/sign_up_input_background"
-        android:hint="@string/sign_up_name"
-        android:inputType="textPersonName"
-        android:maxLength="30"
-        android:padding="8dp"
-        android:textColorHint="@color/sign_up_input_hint_text_color"
-        android:textSize="17dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_name"
-        app:layout_constraintWidth_percent="0.8" />
+        <EditText
+            android:id="@+id/et_nickname"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:background="@drawable/sign_up_input_background"
+            android:hint="@string/sign_up_nickname_text"
+            android:inputType="text"
+            android:maxLength="10"
+            android:padding="8dp"
+            android:textColorHint="@color/sign_up_input_hint_text_color"
+            android:textSize="16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_nickname"
+            app:layout_constraintWidth_percent="0.8" />
 
-    <EditText
-        android:id="@+id/et_phone_number"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
-        android:background="@drawable/sign_up_input_background"
-        android:hint="@string/sign_up_phone_number_text"
-        android:padding="8dp"
-        android:textColorHint="@color/sign_up_input_hint_text_color"
-        android:textSize="17dp"
-        android:inputType="phone"
-        android:maxLength="11"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_phone_number"
-        app:layout_constraintWidth_percent="0.8" />
+        <EditText
+            android:id="@+id/et_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:background="@drawable/sign_up_input_background"
+            android:hint="@string/sign_up_name"
+            android:inputType="textPersonName"
+            android:maxLength="30"
+            android:padding="8dp"
+            android:textColorHint="@color/sign_up_input_hint_text_color"
+            android:textSize="16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_name"
+            app:layout_constraintWidth_percent="0.8" />
 
-    <EditText
-        android:id="@+id/et_state_message"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
-        android:background="@drawable/sign_up_input_background"
-        android:hint="@string/sign_up_state_message_hint"
-        android:padding="8dp"
-        android:textColorHint="@color/sign_up_input_hint_text_color"
-        android:textSize="17dp"
-        android:inputType="text"
-        android:maxLength="60"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_state_message"
-        app:layout_constraintWidth_percent="0.8" />
+        <EditText
+            android:id="@+id/et_phone_number"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:background="@drawable/sign_up_input_background"
+            android:hint="@string/sign_up_phone_number_text"
+            android:inputType="phone"
+            android:maxLength="11"
+            android:padding="8dp"
+            android:textColorHint="@color/sign_up_input_hint_text_color"
+            android:textSize="16dp"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_phone_number"
+            app:layout_constraintWidth_percent="0.8" />
 
-    <EditText
-        android:id="@+id/et_email"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
-        android:background="@drawable/sign_up_input_background"
-        android:hint="@string/sign_up_email_title"
-        android:padding="8dp"
-        android:textColorHint="@color/sign_up_input_hint_text_color"
-        android:textSize="17dp"
-        android:inputType="textEmailAddress"
-        android:maxLength="30"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_email"
-        app:layout_constraintWidth_percent="0.8" />
+        <EditText
+            android:id="@+id/et_state_message"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:background="@drawable/sign_up_input_background"
+            android:hint="@string/sign_up_state_message_hint"
+            android:inputType="text"
+            android:maxLength="60"
+            android:padding="8dp"
+            android:textColorHint="@color/sign_up_input_hint_text_color"
+            android:textSize="16dp"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_state_message"
+            app:layout_constraintWidth_percent="0.8" />
 
-    <ImageButton
-        android:id="@+id/img_btn_profile_image"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="15dp"
-        android:cropToPadding="true"
-        android:scaleType="fitXY"
-        android:adjustViewBounds="true"
-        android:background="@drawable/ic_default_profile_image"
-        app:layout_constraintBottom_toTopOf="@id/et_nickname"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.1" />
+        <EditText
+            android:id="@+id/et_email"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:background="@drawable/sign_up_input_background"
+            android:hint="@string/sign_up_email_title"
+            android:inputType="textEmailAddress"
+            android:maxLength="30"
+            android:padding="8dp"
+            android:textColorHint="@color/sign_up_input_hint_text_color"
+            android:textSize="16dp"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_email"
+            app:layout_constraintWidth_percent="0.8" />
 
-    <TextView
-        android:id="@+id/tv_add_profile"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
-        android:text="@string/sign_up_add_profile_text"
-        android:textColor="@color/black"
-        android:textSize="18dp"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/img_btn_profile_image" />
+        <ImageButton
+            android:id="@+id/img_btn_back"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="15dp"
+            android:background="@drawable/ic_baseline_arrow_back_black_24"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/tv_nickname"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:text="@string/sign_up_nickname_text"
-        android:textColor="@color/black"
-        android:textSize="19dp"
-        app:layout_constraintBottom_toTopOf="@id/et_nickname"
-        app:layout_constraintStart_toStartOf="@id/et_nickname"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_name_error"
-        />
+        <ImageButton
+            android:id="@+id/img_btn_profile_image"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="25dp"
+            android:adjustViewBounds="true"
+            android:background="@drawable/ic_default_profile_image"
+            android:cropToPadding="true"
+            android:scaleType="fitXY"
+            app:layout_constraintBottom_toTopOf="@id/et_nickname"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.1" />
 
-    <TextView
-        android:id="@+id/tv_name"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="22dp"
-        android:text="@string/sign_up_name"
-        android:textColor="@color/black"
-        android:textSize="19dp"
-        app:layout_constraintBottom_toTopOf="@id/et_name"
-        app:layout_constraintStart_toStartOf="@id/et_name"
-        app:layout_constraintTop_toBottomOf="@id/tv_add_profile" />
-    <TextView
-        android:id="@+id/tv_phone_number"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:text="@string/sign_up_phone_number_text"
-        android:textColor="@color/black"
-        android:textSize="19dp"
-        app:layout_constraintBottom_toTopOf="@id/et_phone_number"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintStart_toStartOf="@id/et_phone_number"
-        app:layout_constraintTop_toBottomOf="@id/tv_nickname_error" />
+        <TextView
+            android:id="@+id/tv_add_profile"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
+            android:text="@string/sign_up_add_profile_text"
+            android:textColor="@color/black"
+            android:textSize="18dp"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/img_btn_profile_image" />
 
-    <TextView
-        android:id="@+id/tv_state_message"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:text="@string/sign_up_state_message_title"
-        android:textColor="@color/black"
-        android:textSize="19dp"
-        app:layout_constraintBottom_toTopOf="@id/et_state_message"
-        app:layout_constraintStart_toStartOf="@id/et_state_message"
-        app:layout_constraintTop_toBottomOf="@id/tv_email_error" />
+        <TextView
+            android:id="@+id/tv_nickname"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/sign_up_nickname_text"
+            android:textColor="@color/black"
+            android:textSize="18dp"
+            app:layout_constraintBottom_toTopOf="@id/et_nickname"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintStart_toStartOf="@id/et_nickname"
+            app:layout_constraintTop_toBottomOf="@id/tv_name_error" />
 
-    <TextView
-        android:id="@+id/tv_user_type"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:text="@string/sign_up_user_type_title"
-        android:textColor="@color/black"
-        android:textSize="19dp"
-        app:layout_constraintStart_toStartOf="@id/tv_email"
-        app:layout_constraintTop_toBottomOf="@id/et_state_message" />
+        <TextView
+            android:id="@+id/tv_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="22dp"
+            android:text="@string/sign_up_name"
+            android:textColor="@color/black"
+            android:textSize="18dp"
+            app:layout_constraintBottom_toTopOf="@id/et_name"
+            app:layout_constraintStart_toStartOf="@id/et_name"
+            app:layout_constraintTop_toBottomOf="@id/tv_add_profile" />
 
-    <TextView
-        android:id="@+id/tv_email"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:text="@string/sign_up_email_title"
-        android:textColor="@color/black"
-        android:textSize="19dp"
-        app:layout_constraintBottom_toTopOf="@id/et_email"
-        app:layout_constraintStart_toStartOf="@id/et_email"
-        app:layout_constraintTop_toBottomOf="@id/tv_phone_number_error" />
+        <TextView
+            android:id="@+id/tv_phone_number"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/sign_up_phone_number_text"
+            android:textColor="@color/black"
+            android:textSize="18dp"
+            app:layout_constraintBottom_toTopOf="@id/et_phone_number"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintStart_toStartOf="@id/et_phone_number"
+            app:layout_constraintTop_toBottomOf="@id/tv_nickname_error" />
 
-    <TextView
-        android:id="@+id/tv_name_error"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textColor="@color/sign_up_input_error_text_color"
-        app:layout_constraintStart_toStartOf="@id/et_name"
-        app:layout_constraintTop_toBottomOf="@id/et_name"
-        android:visibility="gone"/>
+        <TextView
+            android:id="@+id/tv_state_message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/sign_up_state_message_title"
+            android:textColor="@color/black"
+            android:textSize="18dp"
+            app:layout_constraintBottom_toTopOf="@id/et_state_message"
+            app:layout_constraintStart_toStartOf="@id/et_state_message"
+            app:layout_constraintTop_toBottomOf="@id/tv_email_error" />
 
-    <TextView
-        android:id="@+id/tv_nickname_error"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textColor="@color/sign_up_input_error_text_color"
-        app:layout_constraintStart_toStartOf="@id/et_nickname"
-        app:layout_constraintTop_toBottomOf="@id/et_nickname"
-        android:visibility="gone"/>
+        <TextView
+            android:id="@+id/tv_user_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/sign_up_user_type_title"
+            android:textColor="@color/black"
+            android:textSize="18dp"
+            app:layout_constraintStart_toStartOf="@id/tv_email"
+            app:layout_constraintTop_toBottomOf="@id/et_state_message" />
 
-    <TextView
-        android:id="@+id/tv_phone_number_error"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textColor="@color/sign_up_input_error_text_color"
-        app:layout_constraintStart_toStartOf="@id/et_phone_number"
-        app:layout_constraintTop_toBottomOf="@id/et_phone_number"
-        android:visibility="gone"/>
+        <TextView
+            android:id="@+id/tv_email"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/sign_up_email_title"
+            android:textColor="@color/black"
+            android:textSize="18dp"
+            app:layout_constraintBottom_toTopOf="@id/et_email"
+            app:layout_constraintStart_toStartOf="@id/et_email"
+            app:layout_constraintTop_toBottomOf="@id/tv_phone_number_error" />
 
-    <TextView
-        android:id="@+id/tv_email_error"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textColor="@color/sign_up_input_error_text_color"
-        app:layout_constraintStart_toStartOf="@id/et_email"
-        app:layout_constraintTop_toBottomOf="@id/et_email"
-        android:visibility="gone"/>
+        <TextView
+            android:id="@+id/tv_name_error"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/sign_up_input_error_text_color"
+            android:visibility="gone"
+            android:textSize="15dp"
+            app:layout_constraintStart_toStartOf="@id/et_name"
+            app:layout_constraintTop_toBottomOf="@id/et_name" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:id="@+id/tv_nickname_error"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/sign_up_input_error_text_color"
+            android:visibility="gone"
+            android:textSize="15dp"
+            app:layout_constraintStart_toStartOf="@id/et_nickname"
+            app:layout_constraintTop_toBottomOf="@id/et_nickname" />
+
+        <TextView
+            android:id="@+id/tv_phone_number_error"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/sign_up_input_error_text_color"
+            android:visibility="gone"
+            android:textSize="15dp"
+            app:layout_constraintStart_toStartOf="@id/et_phone_number"
+            app:layout_constraintTop_toBottomOf="@id/et_phone_number" />
+
+        <TextView
+            android:id="@+id/tv_email_error"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/sign_up_input_error_text_color"
+            android:visibility="gone"
+            android:textSize="15dp"
+            app:layout_constraintStart_toStartOf="@id/et_email"
+            app:layout_constraintTop_toBottomOf="@id/et_email" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.core.widget.NestedScrollView>

--- a/Breaking/app/src/main/res/layout/custom_dialog_multiple_button.xml
+++ b/Breaking/app/src/main/res/layout/custom_dialog_multiple_button.xml
@@ -21,7 +21,7 @@
         android:orientation="horizontal">
         <Button
             android:id="@+id/btn_dialog_multi_left"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_weight="1"
             android:layout_height="wrap_content"
             android:background="@drawable/custom_dialog_multi_left_background"
@@ -29,7 +29,7 @@
             android:textSize="11sp"/>
         <Button
             android:id="@+id/btn_dialog_multi_right"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_weight="1"
             android:layout_height="wrap_content"
             android:background="@drawable/custom_dialog_multi_right_background"

--- a/Breaking/app/src/main/res/layout/fragment_navi_user.xml
+++ b/Breaking/app/src/main/res/layout/fragment_navi_user.xml
@@ -28,71 +28,16 @@
             android:background="@drawable/my_profile_edit_profile_btn_background"
             android:text="@string/edit_profile"
             android:textSize="10sp"
-            app:layout_constraintBottom_toBottomOf="@id/imgv_my_page_profile"
+            app:layout_constraintBottom_toBottomOf="@id/img_view_my_page_profile"
             app:layout_constraintHeight_percent="0.03"
-            app:layout_constraintLeft_toRightOf="@id/imgv_my_page_profile"
+            app:layout_constraintLeft_toRightOf="@id/img_view_my_page_profile"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_my_page_status"
             app:layout_constraintVertical_bias="1.0"
             app:layout_constraintWidth_percent="0.6" />
 
-        <!--        <GridView-->
-        <!--            android:id="@+id/gv_feed_list"-->
-        <!--            android:layout_width="wrap_content"-->
-        <!--            android:layout_height="wrap_content"-->
-        <!--            android:numColumns="2"-->
-        <!--            app:layout_constraintBottom_toBottomOf="parent"-->
-        <!--            app:layout_constraintEnd_toEndOf="parent"-->
-        <!--            app:layout_constraintStart_toStartOf="parent"-->
-        <!--            app:layout_constraintTop_toBottomOf="@id/img_btn_written" />-->
-
-<!--        <ImageButton-->
-<!--            android:id="@+id/img_btn_written"-->
-<!--            android:layout_width="0dp"-->
-<!--            android:layout_height="0dp"-->
-<!--            android:background="@drawable/feed_category_button_background"-->
-<!--            android:src="@drawable/ic_baseline_create_24"-->
-<!--            app:layout_constraintBottom_toBottomOf="parent"-->
-<!--            app:layout_constraintEnd_toEndOf="parent"-->
-<!--            app:layout_constraintHeight_percent="0.05"-->
-<!--            app:layout_constraintHorizontal_bias="0.3"-->
-<!--            app:layout_constraintStart_toStartOf="parent"-->
-<!--            app:layout_constraintTop_toBottomOf="@id/divider"-->
-<!--            app:layout_constraintVertical_bias="0.02"-->
-<!--            app:layout_constraintWidth_percent="0.15" />-->
-<!---->
-<!--        <ImageButton-->
-<!--            android:id="@+id/img_btn_bought"-->
-<!--            android:layout_width="0dp"-->
-<!--            android:layout_height="0dp"-->
-<!--            android:background="@drawable/feed_category_button_background"-->
-<!--            android:src="@drawable/ic_baseline_add_shopping_cart_24"-->
-<!--            app:layout_constraintBottom_toBottomOf="parent"-->
-<!--            app:layout_constraintEnd_toEndOf="parent"-->
-<!--            app:layout_constraintHeight_percent="0.05"-->
-<!--            app:layout_constraintHorizontal_bias="0.5"-->
-<!--            app:layout_constraintStart_toStartOf="parent"-->
-<!--            app:layout_constraintTop_toBottomOf="@id/divider"-->
-<!--            app:layout_constraintVertical_bias="0.02"-->
-<!--            app:layout_constraintWidth_percent="0.15" />-->
-<!---->
-<!--        <ImageButton-->
-<!--            android:id="@+id/img_btn_bookmark"-->
-<!--            android:layout_width="0dp"-->
-<!--            android:layout_height="0dp"-->
-<!--            android:background="@drawable/feed_category_button_background"-->
-<!--            android:src="@drawable/ic_baseline_bookmark_border_24"-->
-<!--            app:layout_constraintBottom_toBottomOf="parent"-->
-<!--            app:layout_constraintEnd_toEndOf="parent"-->
-<!--            app:layout_constraintHeight_percent="0.05"-->
-<!--            app:layout_constraintHorizontal_bias="0.7"-->
-<!--            app:layout_constraintStart_toStartOf="parent"-->
-<!--            app:layout_constraintTop_toBottomOf="@id/divider"-->
-<!--            app:layout_constraintVertical_bias="0.02"-->
-<!--            app:layout_constraintWidth_percent="0.15" />-->
-<!---->
         <ImageView
-            android:id="@+id/imgv_my_page_profile"
+            android:id="@+id/img_view_my_page_profile"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="10dp"
@@ -115,8 +60,8 @@
             android:textColor="@color/black"
             android:textSize="18sp"
             android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="@id/imgv_my_page_profile"
-            app:layout_constraintLeft_toRightOf="@id/imgv_my_page_profile"
+            app:layout_constraintBottom_toBottomOf="@id/img_view_my_page_profile"
+            app:layout_constraintLeft_toRightOf="@id/img_view_my_page_profile"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_bias="0.2"
@@ -130,8 +75,8 @@
             android:padding="5dp"
             android:text="@string/status_msg"
             android:textSize="13sp"
-            app:layout_constraintBottom_toBottomOf="@id/imgv_my_page_profile"
-            app:layout_constraintLeft_toRightOf="@id/imgv_my_page_profile"
+            app:layout_constraintBottom_toBottomOf="@id/img_view_my_page_profile"
+            app:layout_constraintLeft_toRightOf="@id/img_view_my_page_profile"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_my_page_nickname"
             app:layout_constraintVertical_bias="0.2"
@@ -147,9 +92,9 @@
             android:textSize="12sp"
             android:textStyle="bold"
             app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintLeft_toLeftOf="@id/imgv_my_page_profile"
+            app:layout_constraintLeft_toLeftOf="@id/img_view_my_page_profile"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/imgv_my_page_profile" />
+            app:layout_constraintTop_toBottomOf="@id/img_view_my_page_profile" />
 
         <TextView
             android:id="@+id/tv_follow_value"
@@ -171,9 +116,9 @@
             android:textSize="12sp"
             android:textStyle="bold"
             app:layout_constraintHorizontal_bias="0.85"
-            app:layout_constraintLeft_toLeftOf="@id/imgv_my_page_profile"
+            app:layout_constraintLeft_toLeftOf="@id/img_view_my_page_profile"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/imgv_my_page_profile" />
+            app:layout_constraintTop_toBottomOf="@id/img_view_my_page_profile" />
 
         <TextView
             android:id="@+id/tv_follower_value"
@@ -195,9 +140,9 @@
             android:textSize="12sp"
             android:textStyle="bold"
             app:layout_constraintHorizontal_bias="0.15"
-            app:layout_constraintLeft_toLeftOf="@id/imgv_my_page_profile"
+            app:layout_constraintLeft_toLeftOf="@id/img_view_my_page_profile"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/imgv_my_page_profile" />
+            app:layout_constraintTop_toBottomOf="@id/img_view_my_page_profile" />
 
         <TextView
             android:id="@+id/tv_post_value"
@@ -219,7 +164,7 @@
             app:layout_constraintHorizontal_bias="0.36"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/imgv_my_page_profile"
+            app:layout_constraintTop_toBottomOf="@id/img_view_my_page_profile"
             app:layout_constraintVertical_bias="0.35" />
 
         <View
@@ -231,7 +176,7 @@
             app:layout_constraintHeight_percent="0.04"
             app:layout_constraintLeft_toLeftOf="@id/tv_follow_title"
             app:layout_constraintRight_toRightOf="@id/tv_follower_title"
-            app:layout_constraintTop_toBottomOf="@id/imgv_my_page_profile"
+            app:layout_constraintTop_toBottomOf="@id/img_view_my_page_profile"
             app:layout_constraintVertical_bias="0.35" />
 
         <View
@@ -251,14 +196,14 @@
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tab_layout"
-            app:tabIndicatorHeight="5dp"
             android:layout_width="0dp"
-            app:layout_constraintWidth_percent="0.7"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
             android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/divider"
+            app:layout_constraintWidth_percent="0.7"
             app:tabIndicatorColor="@color/breaking_color"
-            app:layout_constraintTop_toBottomOf="@id/divider" />
+            app:tabIndicatorHeight="5dp" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </LinearLayout>

--- a/Breaking/app/src/main/res/values/strings.xml
+++ b/Breaking/app/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
     <string name="drawer_menu_breaking_cart">구매한 제보</string>
     <string name="drawer_menu_breaking_profile">프로필 편집</string>
     <string name="drawer_menu_breaking_setting">설정</string>
-    <string name="edit_profile">프로필 편집하기</string>
+    <string name="edit_profile">프로필 편집</string>
     <string name="nickname">닉네임</string>
     <string name="status_msg">상태 메세지</string>
     <string name="follow">팔로우</string>


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #42 

## 예상 리뷰 시간
15-min

## 추가 또는 변경사항
- 회원가입 페이지를 재활용하여 유저 프로필 편집하기 페이지 구현
  - 일부 view만 프로필 편집에 맞도록 수정
  - 기존 유저 데이터 가져와서 프로필 편집 페이지에 각 데이터 뿌려주기
  - 필드 검증 재활용
  - 이미지 수정에서 dialog로 기본이미지와 갤러리에서 가져오기 선택하도록 구현
  - 유저 프로필 수정 요청
  - 요청한 결과 가져와서 유저 프로필 페이지에 반영
- 유저 페이지에서 프로필 클릭 시, 애니메이션 효과와 함께 이미지 확대
- 코드 warning 해결
- 코드 리팩토링 
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
- 유저 프로필 편집 페이지(회원가입 레이아웃 재활용)
<img src = "https://user-images.githubusercontent.com/54919474/180936622-feb1a364-1a38-4979-99da-3bdf429daaff.png" width="30%" height="30%">

- 이미지 클릭 시 호출되는 프로필 이미지 선택 dialog
<img src = "https://user-images.githubusercontent.com/54919474/180936645-ea277862-e406-484e-ad09-d844ed9ba28b.png" width="30%" height="30%">

- 수정 완료 후 유저 페이지
<img src = "https://user-images.githubusercontent.com/54919474/180936658-eb110702-2c7d-4654-b882-f5266c06fa45.png" width="30%" height="30%">

- 유저 페이지에서 이미지 클릭 시 이미지 확대
<img src = "https://user-images.githubusercontent.com/54919474/180936668-55907dc3-bdc3-4242-a5a6-a4294578d2f7.png" width="30%" height="30%">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 여러 클래스에서 반복되서 사용되는 상수 값을 사용하다 보니 리팩토링이 필요해보여서 그러한 값들을 저장하는 클래스를 따로 생성하여 그곳에 저장하도록 하고(companion object로) 그 클래스로 호출해서 사용하도록 리팩토링을 했다. 
- 피그마를 바탕으로 유저 프로필 편집 페이지를 따로 만드는 것은 비효율적이라고 생각하여 회원가입 레이아웃을 그대로 가져와서 일부 view만 수정하게끔 하여 리소스를 효율적으로 사용하도록 했다.
- 프로필 편집 Activity에서 유저 프로필 Fragment로 뒤로가기할 때 수정을 했는지 안했는지를 판단하여 유저 프로필 Fragment의 lifecycle 콜백 메소드에서 유저 프로필 데이터를 갱신하게끔 구현하려고 했지만 Fragment가 묶여있는 Activity가 아닌 다른 Activity에서 Fragment로 데이터를 전달하는 방법을 도저히 찾지 못하여, 결국에는 수정 완료 여부에 관계없이 뒤로 돌아갔을 때 유저 정보가 갱신되도록 구현을 하였다. (팔로우, 팔로워 등에 대한 값 변동도 있을 것라는 합리화를 하며..)
- 갱신할 때는 만들어둔 LoadingFragment를 재활용하여 Fragment replace만 해주었다. 하지만 여기서 문제는 최초로 유저 Fragment가 호출될 때 lifecycle 메소드도 호출되기 때문에 무한호출이 이루어지게 되었다. 이를 해결하기 위해 onCreateView() 콜백 호출 여부를 판단하는 flag 변수를 만들어서 구분을 해주었다.  