### PR TITLE
hotfix: update user profile according to changed api  

### DIFF
--- a/Breaking/app/src/main/java/com/dope/breaking/EditProfileActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/EditProfileActivity.kt
@@ -35,6 +35,7 @@ class EditProfileActivity : AppCompatActivity() {
     private lateinit var galleryActivityResult: ActivityResultLauncher<Intent> // 갤러리에서 이미지를 가져왔을 때의 처리를 위한 activityResult
     private var filename: String = "" // 프로필 이미지 파일명
     private var profileImgBitmap: Bitmap? = null // 프로필 이미지 비트맵 전역변수
+    private var isDefaultImage = false // 기본 이미지를 사용하냐 안하냐 구분
     private val handler = object : Handler(Looper.getMainLooper()) { // 메인 스레드에서 비트맵 변수 받아와서 할당
         override fun handleMessage(msg: Message) {
             profileImgBitmap = msg.data.getParcelable("Bitmap")!! // 번들에서 비트맵 객체를 받아온다.
@@ -127,6 +128,7 @@ class EditProfileActivity : AppCompatActivity() {
                             realName,
                             role,
                             statusMsg,
+                            profileImgBitmap != null || isDefaultImage
                         ) // 필드 객체
 
                         val account = Account()
@@ -229,6 +231,7 @@ class EditProfileActivity : AppCompatActivity() {
                         .into(binding.imgBtnProfileImage) // 기본 이미지로 보여주기
                     profileImgBitmap = null
                     filename = ""
+                    isDefaultImage = true // 기본 이미지 사용
                 },
                 {
                     // 갤러리 intent 호출

--- a/Breaking/app/src/main/java/com/dope/breaking/model/request/RequestUpdateUser.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/request/RequestUpdateUser.kt
@@ -9,12 +9,13 @@ data class RequestUpdateUser(
     val realName: String,
     val role: String,
     val statusMsg: String,
-){
+    val isProfileImgChanged: Boolean
+) {
     /**
      * 모든 필드 값들을 json 데이터로 변환해주는 메소드
      * @return JSONObject: 모든 필드들을 json 으로 변환한 객체 반환
      * @author Seunggun Sin
-     * @since 2022-07-25
+     * @since 2022-07-25 | 2022-08-01
      */
     fun convertFieldsToJson(): JSONObject {
         val jsonObject = JSONObject()
@@ -24,6 +25,7 @@ data class RequestUpdateUser(
         jsonObject.put("realName", realName)
         jsonObject.put("role", role)
         jsonObject.put("statusMsg", statusMsg)
+        jsonObject.put("isProfileImgChanged", isProfileImgChanged)
         return jsonObject
     }
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #57 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 프로필 이미지 변경 이슈에 대한 백엔드에서의 api 변경으로 인한 프로필 변경 핫픽스
  - isProfileImgChanged 필드 추가로 프로필 이미지 변경 여부 확인
  - 기본 이미지 사용 시, isProfileImgChanged = true && 이미지 데이터 = null
  - 그외 나머지 필드 변경은 동일해서 추가적인 수정 x
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
- 기존 프로필 이미지 -> 새로운 프로필 이미지 변경 : 성공
- 기존 프로필 이미지 -> 기본 이미지 사용 : 성공
- 기본 이미지 -> 새로운 프로필 이미지 변경 : 성공
- 기존 프로필 이미지 -> 프로필 변경 없이 다른 필드 값 변경 : 성공
## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 모듈화 덕분에 코드 5줄만으로 수정해서 좀 머쓱하다. (유지보수 및 생산성 좋은 코드 최고!)
- `profileImgBitmap != null || isDefaultImage` 로직으로 사용