### PR TITLE
feat: implement main home layout with feed 

### DIFF
--- a/Breaking/app/src/main/AndroidManifest.xml
+++ b/Breaking/app/src/main/AndroidManifest.xml
@@ -74,7 +74,8 @@
             android:exported="true" />
         <activity
             android:name=".MainActivity"
-            android:exported="true" />
+            android:exported="true"
+            android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".SignUpActivity"
             android:exported="false" />
@@ -89,6 +90,7 @@
                 android:resource="@xml/provider_paths" />
         </provider>
     </application>
+
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/Breaking/app/src/main/java/com/dope/breaking/adapter/FollowAdapter.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/adapter/FollowAdapter.kt
@@ -199,11 +199,11 @@ class FollowAdapter(
      * "팔로우" 버튼 상태로 전환(텍스트, 배경 변경)
      * @param button(Button): 우측 버튼 view
      * @author Seunggun Sin
-     * @since 2022-08-02
+     * @since 2022-08-02 | 2022-08-09
      */
     private fun convertToFollowState(button: Button) {
         button.text = "팔로우"
-        button.setBackgroundResource(R.drawable.sign_up_user_type_selected)
+        button.setBackgroundResource(R.drawable.sign_up_user_type_unselected)
     }
 
     /**

--- a/Breaking/app/src/main/java/com/dope/breaking/adapter/UserPostAdapter.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/adapter/UserPostAdapter.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
@@ -13,10 +12,14 @@ import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.bumptech.glide.request.RequestOptions
 import com.dope.breaking.R
+import com.dope.breaking.model.response.ResponseMainFeed
+import com.dope.breaking.util.DateUtil
 import com.dope.breaking.util.ValueUtil
+import java.text.DecimalFormat
 
-class UserPostAdapter(private val context: Context, var data: MutableList<String>) :
+class UserPostAdapter(private val context: Context, var data: MutableList<ResponseMainFeed>) :
     RecyclerView.Adapter<UserPostAdapter.ViewHolder>() {
+    private val decimalFormat = DecimalFormat("#,###") // 숫자 콤마 포맷을 위한 클래스
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UserPostAdapter.ViewHolder {
         val view = LayoutInflater.from(context).inflate(R.layout.item_post_list, parent, false)
         return ViewHolder(view)
@@ -31,15 +34,44 @@ class UserPostAdapter(private val context: Context, var data: MutableList<String
     }
 
     inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-        val thumbnail = itemView.findViewById<ImageView>(R.id.imgv_post_thumbnail)
-        fun bind(item: String) {
-            Glide.with(itemView)
-                .load(ValueUtil.IMAGE_BASE_URL + item)
-                .placeholder(R.drawable.ic_default_post_image_size_up)
-                .error(R.drawable.ic_default_post_image_size_up)
-                .apply(RequestOptions().transform(CenterCrop(), RoundedCorners(24)))
+        private val thumbnail = itemView.findViewById<ImageView>(R.id.imgv_post_thumbnail)
+        private val title = itemView.findViewById<TextView>(R.id.tv_post_title)
+        private val likeCount = itemView.findViewById<TextView>(R.id.tv_post_like_count)
+        private val price = itemView.findViewById<TextView>(R.id.tv_post_price)
+        private val chipExclusive = itemView.findViewById<TextView>(R.id.tv_chip_exclusive)
+        private val chipSold = itemView.findViewById<TextView>(R.id.tv_chip_sold)
+        private val chipUnsold = itemView.findViewById<TextView>(R.id.tv_chip_unsold)
+        private val nickname = itemView.findViewById<TextView>(R.id.tv_post_nickname)
+        private val date = itemView.findViewById<TextView>(R.id.tv_post_time)
+        private val location = itemView.findViewById<TextView>(R.id.tv_post_location)
 
-                .into(thumbnail)
+        fun bind(item: ResponseMainFeed) {
+            if (item.thumbnailImgURL == null) {
+                Glide.with(itemView)
+                    .load(R.drawable.ic_default_post_image_size_up)
+                    .apply(RequestOptions().transform(CenterCrop(), RoundedCorners(24)))
+                    .into(thumbnail)
+            } else {
+                Glide.with(itemView)
+                    .load(ValueUtil.IMAGE_BASE_URL + item.thumbnailImgURL)
+                    .placeholder(R.drawable.ic_default_post_image_size_up)
+                    .error(R.drawable.ic_default_post_image_size_up)
+                    .apply(RequestOptions().transform(CenterCrop(), RoundedCorners(24)))
+                    .into(thumbnail)
+            }
+            title.text = item.title
+            likeCount.text = item.likeCount.toString()
+            price.text = decimalFormat.format(item.price) + "원"
+            chipExclusive.visibility = if (item.postType == "EXCLUSIVE") View.VISIBLE else View.GONE
+
+            if (item.postType == "FREE" || item.price == 0)
+                price.text = "무료"
+
+            location.text = item.location.region_2depth_name
+            chipSold.visibility = if (item.isSold) View.VISIBLE else View.GONE
+            chipUnsold.visibility = if (item.isSold) View.GONE else View.VISIBLE
+            nickname.text = if (item.user == null) "익명" else item.user.nickname
+            date.text = DateUtil().getTimeDiff(item.createdDate)
         }
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/board/PostActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/board/PostActivity.kt
@@ -51,11 +51,12 @@ import java.util.*
 import kotlin.collections.ArrayList
 
 
-class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, TimePickerDialog.OnTimeSetListener{
+class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener,
+    TimePickerDialog.OnTimeSetListener {
 
     private val TAG = "PostActivity.kt" // Tag Log
 
-    private var mbinding : ActivityPostBinding? = null
+    private var mbinding: ActivityPostBinding? = null
 
     private val binding get() = mbinding!!
 
@@ -73,9 +74,10 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
 
     private lateinit var hashTagList: ArrayList<String> // 해시 태그 리스트
 
-    private lateinit var eventTime :String // 제보 발생 시간
+    private lateinit var eventTime: String // 제보 발생 시간
 
-    private var isPostTypeSelected: String = "charged" // 제보 방식으로, 단독, 유료, 무료 제보로 나뉘고 기본값은 유료 제보로 설정.
+    private var isPostTypeSelected: String =
+        "charged" // 제보 방식으로, 단독, 유료, 무료 제보로 나뉘고 기본값은 유료 제보로 설정.
 
     private var isAnonymousSelected: Boolean = false // 익명 여부로, true-> 익명, false-> 공개이고 기본값은 공개로 설정.
 
@@ -87,7 +89,7 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
     private var day = 0
     private var month = 0
     private var year = 0
-    private var hour  = 0
+    private var hour = 0
     private var min = 0
     private var second = 0
 
@@ -95,7 +97,7 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
     private var savedDay = 0
     private var savedMonth = 0
     private var savedYear = 0
-    private var savedHour  = 0
+    private var savedHour = 0
     private var savedMin = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -110,16 +112,17 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
             }
         }
 
-        val textWatcher = object :TextWatcher{ // 제보 가격 입력 필드 실시간 감지 콜백 함수
-            override fun beforeTextChanged(s: CharSequence?, p1: Int, p2: Int, p3: Int) { }
+        val textWatcher = object : TextWatcher { // 제보 가격 입력 필드 실시간 감지 콜백 함수
+            override fun beforeTextChanged(s: CharSequence?, p1: Int, p2: Int, p3: Int) {}
             override fun onTextChanged(s: CharSequence?, p1: Int, p2: Int, p3: Int) {
-                if(!TextUtils.isEmpty(s.toString()) && s.toString() != postPriceString){ // 가격 입력 필드가 비워져 있지 않고, 값 변동이 없을 때만 작동하도록 (무한 루프 방지)
-                    postPriceString = decimalFormat.format((s.toString().replace(",","")).toInt());
+                if (!TextUtils.isEmpty(s.toString()) && s.toString() != postPriceString) { // 가격 입력 필드가 비워져 있지 않고, 값 변동이 없을 때만 작동하도록 (무한 루프 방지)
+                    postPriceString = decimalFormat.format((s.toString().replace(",", "")).toInt());
                     binding.etPostPrice.setText(postPriceString); // ,이용하여 가격 표시
                     binding.etPostPrice.setSelection(postPriceString.length); // 커서 위치 변경
                 }
             }
-            override fun afterTextChanged(s: Editable?) { }
+
+            override fun afterTextChanged(s: Editable?) {}
         }
 
         uriList = ArrayList<Uri>() // Uri 리스트 초기화
@@ -142,36 +145,77 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
         galleryActivityResult =
             registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
                 if (it.resultCode == RESULT_OK) {   // 갤러리에서 이미지를 정상적으로 선택했다면
-                    try{
-                        if(it.data?.clipData == null){ // 여러 장 선택을 지원하지 않는 기기에서 이미지&영상을 하나만 선택한 경우 (연식 오래된 구 휴대폰들)
+                    try {
+                        if (it.data?.clipData == null) { // 여러 장 선택을 지원하지 않는 기기에서 이미지&영상을 하나만 선택한 경우 (연식 오래된 구 휴대폰들)
                             var uri = it.data?.data
-                            if(uriList.size < 10){
+                            if (uriList.size < 10) {
                                 uriList.add(uri!!)
-                                adapter = MultiImageAdapter(uriList, fileNameList,postBitmapList, applicationContext, binding)
+                                adapter = MultiImageAdapter(
+                                    uriList,
+                                    fileNameList,
+                                    postBitmapList,
+                                    applicationContext,
+                                    binding
+                                )
                                 binding.viewRecyclerImage.adapter = adapter
-                                binding.viewRecyclerImage.layoutManager = LinearLayoutManager(this,LinearLayoutManager.HORIZONTAL, true) // 수평 스크롤 적용
-                            }else
-                                Toast.makeText(applicationContext,"제보 미디어 파일은 총 20장까지 가능합니다.",Toast.LENGTH_SHORT).show()
+                                binding.viewRecyclerImage.layoutManager = LinearLayoutManager(
+                                    this,
+                                    LinearLayoutManager.HORIZONTAL,
+                                    true
+                                ) // 수평 스크롤 적용
+                            } else
+                                Toast.makeText(
+                                    applicationContext,
+                                    "제보 미디어 파일은 총 20장까지 가능합니다.",
+                                    Toast.LENGTH_SHORT
+                                ).show()
                             // 해당 버전에서 파일명 처리는 추후에 할 예정
 
-                        }else{ // 여러 장 선택을 지원하는 기기에서 이미지&영상을 한 장 혹은 여러 장 선택한 경우
+                        } else { // 여러 장 선택을 지원하는 기기에서 이미지&영상을 한 장 혹은 여러 장 선택한 경우
                             var clipData = it.data?.clipData
-                            if((clipData!!.itemCount + uriList.size) <= 20){ // 내가 올려놓은 사진들의 개수와 갤러리에서 추가적으로 선택한 사진 개수의 합이 10장을 초과하지 않아야 저장 O
-                                changeUploadImageColors(clipData!!.itemCount, uriList.size) // 최대 개수면 사진 카운트 텍스트 색상 변경
-                                for(i in 0 until clipData.itemCount){   // 선택한 미디어 파일의 개수만큼 반복문
-                                    var uri = clipData.getItemAt(i).uri // 해당 인덱스의 선택한 이미지의 uri를 가져오기
-                                    fileNameList.add(Utils.getFileNameFromURI(uri!!, contentResolver)!!)
+                            if ((clipData!!.itemCount + uriList.size) <= 20) { // 내가 올려놓은 사진들의 개수와 갤러리에서 추가적으로 선택한 사진 개수의 합이 10장을 초과하지 않아야 저장 O
+                                changeUploadImageColors(
+                                    clipData!!.itemCount,
+                                    uriList.size
+                                ) // 최대 개수면 사진 카운트 텍스트 색상 변경
+                                for (i in 0 until clipData.itemCount) {   // 선택한 미디어 파일의 개수만큼 반복문
+                                    var uri =
+                                        clipData.getItemAt(i).uri // 해당 인덱스의 선택한 이미지의 uri를 가져오기
+                                    fileNameList.add(
+                                        Utils.getFileNameFromURI(
+                                            uri!!,
+                                            contentResolver
+                                        )!!
+                                    )
                                     uriList.add(uri)
-                                    Utils.getBitmapWithGlide(applicationContext, uri, handler) // 비트맵 리스트에 하나씩 추가
+                                    Utils.getBitmapWithGlide(
+                                        applicationContext,
+                                        uri,
+                                        handler
+                                    ) // 비트맵 리스트에 하나씩 추가
                                 }
-                                adapter = MultiImageAdapter(uriList, fileNameList, postBitmapList, applicationContext, binding)
+                                adapter = MultiImageAdapter(
+                                    uriList,
+                                    fileNameList,
+                                    postBitmapList,
+                                    applicationContext,
+                                    binding
+                                )
                                 binding.viewRecyclerImage.adapter = adapter
-                                binding.viewRecyclerImage.layoutManager = LinearLayoutManager(this,LinearLayoutManager.HORIZONTAL, true) // 수평 스크롤 적용
-                            }else{
-                                Toast.makeText(applicationContext,"제보 미디어 파일은 총 20장까지 가능합니다.",Toast.LENGTH_SHORT).show()
+                                binding.viewRecyclerImage.layoutManager = LinearLayoutManager(
+                                    this,
+                                    LinearLayoutManager.HORIZONTAL,
+                                    true
+                                ) // 수평 스크롤 적용
+                            } else {
+                                Toast.makeText(
+                                    applicationContext,
+                                    "제보 미디어 파일은 총 20장까지 가능합니다.",
+                                    Toast.LENGTH_SHORT
+                                ).show()
                             }
                         }
-                    }catch (e: ErrorFileSelectedException){
+                    } catch (e: ErrorFileSelectedException) {
                         DialogUtil().SingleDialog( // 미디어 선택에 문제가 있는 경우
                             this,
                             "미디어 파일 선택 중 에러가 발생하였습니다.",
@@ -191,14 +235,14 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
      * @author - Tae hyun Park
      * @since - 2022-07-31
      */
-    private fun clickPostPageButtons(){
+    private fun clickPostPageButtons() {
         // 이미지 제보 버튼이 눌렸다면 갤러리 인텐트 함수 호출
-        binding.layoutImageButton.setOnClickListener{
+        binding.layoutImageButton.setOnClickListener {
             selectGalleryIntent()
         }
 
         // 이미지 제보 버튼이 눌렸다면 갤러리 인텐트 함수 호출
-        binding.ibUploadPicture.setOnClickListener{
+        binding.ibUploadPicture.setOnClickListener {
             selectGalleryIntent()
         }
 
@@ -249,10 +293,10 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
         // 제보하기 버튼을 누르면
         binding.btnPostRegisterBtn.setOnClickListener {
             // 미디어 파일 선택 안하면, 기본 이미지 넣어주도록 처리 필요
-            if(postBitmapList.size == 0){
+            if (postBitmapList.size == 0) {
                 postBitmapList.add(ValueUtil.getDefaultPost(this@PostActivity))
                 fileNameList.add("default.png")
-            }else{
+            } else {
                 postBitmapList.removeAt(0)
                 fileNameList.removeAt(0)
             }
@@ -260,21 +304,22 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
             /* 지도 API 로 현재 위치는 처리 예정 */
 
             // 해시 태그 값이 있는지 확인, 태그가 없다면 기본 값으로 다시 초기화
-            if(binding.etContent.text.toString().indexOf('#') !== -1){
-                hashTagList = Utils.getArrayHashTag(binding.etContent.text.toString()) // 해시 태그 처리하여 태그 문자열 추출
-            }else{
+            if (binding.etContent.text.toString().indexOf('#') !== -1) {
+                hashTagList =
+                    Utils.getArrayHashTag(binding.etContent.text.toString()) // 해시 태그 처리하여 태그 문자열 추출
+            } else {
                 hashTagList.clear() // 해시 태그 값이 없으면 리스트 재 초기화
             }
 
             // 필드 검증
             val validationPost = ValidationPost()
-            if(validationPost.startPostValidation(binding)){ // 필드 검증이 성공적이라면
+            if (validationPost.startPostValidation(binding)) { // 필드 검증이 성공적이라면
                 // 요청 DTO 생성
                 val requestPostData = RequestPostData(
                     binding.etTitle.text.toString(),
                     binding.etContent.text.toString(),
-                    PostLocation("경기도",1.43211,2.35456),
-                    binding.etPostPrice.text.toString().replace(",","").toInt(),
+                    PostLocation("경기도", 1.43211, 2.35456, "힝", "힝"),
+                    binding.etPostPrice.text.toString().replace(",", "").toInt(),
                     hashTagList,
                     isPostTypeSelected,
                     isAnonymousSelected,
@@ -315,7 +360,7 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
         inputData: RequestPostData,
         imageData: ArrayList<Bitmap>,
         imageName: ArrayList<String>,
-        token : String
+        token: String
     ) {
         val postManager = PostManager() // 커스텀 게시글 객체 생성
         try {
@@ -326,7 +371,7 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
                 token
             )
             Log.d(TAG, "요청 성공 시 받아온 postId : ${responsePostUpload.postId}")
-        }catch (e: ResponseErrorException){
+        } catch (e: ResponseErrorException) {
             e.printStackTrace()
             DialogUtil().SingleDialog(
                 this,
@@ -372,16 +417,16 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
 
     /**
      * @description - activity_post.xml에서 이미 최상위 NestedScrollView가 정의되어 있기 때문에 EditText에 스크롤 옵션을 주어도 이벤트가 막히는 현상이 발생한다.
-                   따라서 해당 메소드를 통해 EditText 가 터치되어있을 때 부모의 스크롤 권한을 가로채고, EditText가 아닌 바깥을 터치한다면 다시 부모 스크롤 뷰가 동작하도록
-                   하는 메소드.
+    따라서 해당 메소드를 통해 EditText 가 터치되어있을 때 부모의 스크롤 권한을 가로채고, EditText가 아닌 바깥을 터치한다면 다시 부모 스크롤 뷰가 동작하도록
+    하는 메소드.
      * @param - None
      * @return - None
      * @author - Tae hyun Park
      * @since - 2022-07-25
      */
-    private fun allowScrollEditText(){
+    private fun allowScrollEditText() {
         // EditText 스크롤 터지 이벤트 리스너
-        binding.etContent.setOnTouchListener(object : View.OnTouchListener{
+        binding.etContent.setOnTouchListener(object : View.OnTouchListener {
             override fun onTouch(v: View?, event: MotionEvent?): Boolean {
                 if (v!!.id === R.id.et_content) { // 안쪽 EditText 를 클릭했다면
                     v!!.parent.requestDisallowInterceptTouchEvent(true) // 부모 뷰의 스크롤 이벤트 비허용
@@ -402,8 +447,8 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
      * @since - 2022-07-30
      **/
     @SuppressLint("ResourceAsColor")
-    private fun changeUploadImageColors(selectItemCount : Int, uriCount : Int){
-        if(selectItemCount + uriCount == 20){ // 사이즈가 꽉 차면 빨간색으로 표시
+    private fun changeUploadImageColors(selectItemCount: Int, uriCount: Int) {
+        if (selectItemCount + uriCount == 20) { // 사이즈가 꽉 차면 빨간색으로 표시
             binding.tvCurrentCountImage.setTextColor(RED)
             binding.tvMiddleCountImage.setTextColor(RED)
             binding.tvTotalCountImage.setTextColor(RED)
@@ -417,7 +462,7 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
      * @author - Tae hyun Park
      * @since - 2022-07-25
      */
-    private fun settingPostToolBar(){
+    private fun settingPostToolBar() {
         setSupportActionBar(binding.postPageToolBar) // 툴 바 설정
         supportActionBar!!.setDisplayHomeAsUpEnabled(true) // 왼쪽 상단 버튼 만들기
         supportActionBar!!.setHomeAsUpIndicator(R.drawable.ic_baseline_arrow_back_24) // 왼쪽 상단 아이콘
@@ -431,7 +476,7 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
      * @author - Tae hyun Park
      * @since - 2022-07-29
      */
-    private fun getDateTimeCalendar(){
+    private fun getDateTimeCalendar() {
         val cal = Calendar.getInstance()  // 현재 시간을 얻어오기 위해 캘린더 객체 선언
         day = cal.get(Calendar.DAY_OF_MONTH)
         month = cal.get(Calendar.MONTH)
@@ -448,18 +493,19 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
      * @author - Tae hyun Park
      * @since - 2022-07-29
      */
-    private fun pickDate(){
+    private fun pickDate() {
         binding.tvEventTimeClicked.setOnClickListener {
             getDateTimeCalendar()
-            var datePicker = DatePickerDialog(this, this, year,month,day)
-            datePicker.datePicker.maxDate = Calendar.getInstance().timeInMillis  // 제보 시 오늘 당일까지만 날짜 선택 가능하도록, 미래의 시간은 선택 불가능하게.
+            var datePicker = DatePickerDialog(this, this, year, month, day)
+            datePicker.datePicker.maxDate =
+                Calendar.getInstance().timeInMillis  // 제보 시 오늘 당일까지만 날짜 선택 가능하도록, 미래의 시간은 선택 불가능하게.
             datePicker.show()
         }
     }
 
     // 툴 바의 item 선택 이벤트 리스너
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        when(item.itemId){
+        when (item.itemId) {
             android.R.id.home -> { // 툴 바의 뒤로가기 키가 눌렸을 때 동작
                 finish()
                 true
@@ -482,7 +528,15 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener, Ti
         savedHour = hourOfDay
         savedMin = minute
         getDateTimeCalendar() // 현재 시간의 초도 가져오기 위함
-        binding.tvEventTimeClicked.text = "$savedYear" + String.format("-%02d-%02d ",savedMonth, savedDay) + String.format("%02d:%02d:%02d",savedHour, savedMin, second) // 서버에 넘겨줘야할 포맷 맞추기
-        eventTime = "$savedYear" + String.format("-%02d-%02d ",savedMonth, savedDay) + String.format("%02d:%02d:%02d",savedHour, savedMin, second)
+        binding.tvEventTimeClicked.text = "$savedYear" + String.format(
+            "-%02d-%02d ",
+            savedMonth,
+            savedDay
+        ) + String.format("%02d:%02d:%02d", savedHour, savedMin, second) // 서버에 넘겨줘야할 포맷 맞추기
+        eventTime = "$savedYear" + String.format(
+            "-%02d-%02d ",
+            savedMonth,
+            savedDay
+        ) + String.format("%02d:%02d:%02d", savedHour, savedMin, second)
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviChatFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviChatFragment.kt
@@ -2,15 +2,8 @@ package com.dope.breaking.fragment
 
 import android.os.Bundle
 import android.view.*
-import android.widget.LinearLayout
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.DividerItemDecoration
-import com.bumptech.glide.Glide
-import com.dope.breaking.R
-import com.dope.breaking.adapter.UserPostAdapter
 import com.dope.breaking.databinding.FragmentNaviChatBinding
-import com.dope.breaking.databinding.ItemPostListBinding
-import com.dope.breaking.util.ValueUtil
 
 class NaviChatFragment : Fragment() {
     private lateinit var binding: FragmentNaviChatBinding
@@ -18,23 +11,9 @@ class NaviChatFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         binding = FragmentNaviChatBinding.inflate(inflater, container, false)
-        var data = mutableListOf<String>()
-        data.add("/static/compressedProfileImg/d6a7cc89-4874-4298-be1b-48e3e63ed66d.jpg")
-        data.add("/static/compressedProfileImg/d6a7cc89-4874-4298-be1b-48e3e63ed66d.jpg")
 
-        val adapter = UserPostAdapter(requireActivity(), data)
-        binding.rcv.addItemDecoration(
-            DividerItemDecoration(
-                requireActivity(),
-                LinearLayout.VERTICAL
-            )
-        )
-        binding.rcv.adapter = adapter
         return binding.root
     }
-//    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-//        activity?.menuInflater?.inflate(R.menu.general_title_menu, menu)
-//    }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviHomeFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviHomeFragment.kt
@@ -3,10 +3,21 @@ package com.dope.breaking.fragment
 import android.content.Intent
 import android.os.Bundle
 import android.view.*
+import android.widget.LinearLayout
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.DividerItemDecoration
 import com.dope.breaking.R
+import com.dope.breaking.adapter.UserPostAdapter
 import com.dope.breaking.board.PostActivity
 import com.dope.breaking.databinding.FragmentNaviHomeBinding
+import com.dope.breaking.model.response.ResponseMainFeed
+import com.dope.breaking.retrofit.RetrofitManager
+import com.dope.breaking.retrofit.RetrofitService
+import com.dope.breaking.util.JwtTokenUtil
+import com.dope.breaking.util.ValueUtil
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
 
 class NaviHomeFragment : Fragment() {
     private var mbinding: FragmentNaviHomeBinding? = null // 바인딩 변수 초기화
@@ -15,15 +26,51 @@ class NaviHomeFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         mbinding = FragmentNaviHomeBinding.inflate(inflater, container, false)
+
+        // 피드 가져오는 요청 임시 처리 - 리팩토링 할 예정
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+        service.requestGetMainFeed(
+            ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(requireActivity()).getTokenFromLocal(),
+            0,
+            16 // 가져올 게시글 개수
+        ).enqueue(object : Callback<List<ResponseMainFeed>?> {
+            override fun onResponse(
+                call: Call<List<ResponseMainFeed>?>,
+                response: Response<List<ResponseMainFeed>?>
+            ) {
+                if (response.isSuccessful) {
+                    val list = mutableListOf<ResponseMainFeed>()
+                    val resList = response.body()
+
+                    resList?.forEach {
+                        list.add(it)
+                    }
+
+                    val adapter = UserPostAdapter(requireActivity(), list)
+                    binding.rcvMainFeed.addItemDecoration(
+                        DividerItemDecoration(
+                            requireActivity(),
+                            LinearLayout.VERTICAL
+                        )
+                    )
+                    binding.rcvMainFeed.adapter = adapter
+                }
+            }
+
+            override fun onFailure(call: Call<List<ResponseMainFeed>?>, t: Throwable) {
+                TODO("Not yet implemented")
+            }
+        })
         // 제보하기 버튼을 누르면 게시글 작성 페이지로 이동
         binding.fabPosting.setOnClickListener {
-            var intent = Intent(activity, PostActivity::class.java)
+            val intent = Intent(activity, PostActivity::class.java)
             startActivity(intent)
         }
         return binding.root
     }
+
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         activity?.menuInflater?.inflate(R.menu.general_title_menu, menu) // 툴 바 아이콘 변경
     }

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/PostTabFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/PostTabFragment.kt
@@ -5,10 +5,6 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.LinearLayout
-import androidx.recyclerview.widget.DividerItemDecoration
-import com.dope.breaking.R
-import com.dope.breaking.adapter.UserPostAdapter
 import com.dope.breaking.databinding.FragmentPostTabBinding
 
 class PostTabFragment : Fragment() {
@@ -19,18 +15,6 @@ class PostTabFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         binding = FragmentPostTabBinding.inflate(inflater, container, false)
-        var data = mutableListOf<String>()
-        data.add("/static/compressedProfileImg/d6a7cc89-4874-4298-be1b-48e3e63ed66d.jpg")
-        data.add("/static/compressedProfileImg/d6a2f759-2af3-4645-a3d9-09034eec6c33.jpg")
-
-        val adapter = UserPostAdapter(requireActivity(), data)
-        binding.rcvUserPost.addItemDecoration(
-            DividerItemDecoration(
-                requireActivity(),
-                LinearLayout.VERTICAL
-            )
-        )
-        binding.rcvUserPost.adapter = adapter
         return binding.root
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/model/PostLocation.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/PostLocation.kt
@@ -3,21 +3,25 @@ package com.dope.breaking.model
 import org.json.JSONObject
 
 data class PostLocation(
-    val region : String,
-    val latitude : Double,
-    val longitude : Double
-){
+    val address: String,
+    val latitude: Double,
+    val longitude: Double,
+    val region_1depth_name: String,
+    val region_2depth_name: String
+) {
     /**
      * 모든 필드 값들을 json 데이터로 변환해주는 메소드
      * @return JSONObject: 모든 필드들을 json 으로 변환한 객체 반환
      * @author Tae hyun Park
-     * @since 2022-07-29
+     * @since 2022-07-29 | 2022-08-09
      */
     fun convertFieldsToJson(): JSONObject {
         val jsonObject = JSONObject()
-        jsonObject.put("region", region)
+        jsonObject.put("address", address)
         jsonObject.put("latitude", latitude)
         jsonObject.put("longitude", longitude)
+        jsonObject.put("region_1depth_name", region_1depth_name)
+        jsonObject.put("region_2depth_name", region_2depth_name)
         return jsonObject
     }
 

--- a/Breaking/app/src/main/java/com/dope/breaking/model/request/RequestPostData.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/request/RequestPostData.kt
@@ -12,10 +12,10 @@ data class RequestPostData(
     val hashtagList: ArrayList<String>,
     val postType: String,
     @get:JsonProperty("isAnonymous")
-    val isAnonymous : Boolean,
-    val eventTime : String,
-    val thumbnailIndex : Int
-){
+    val isAnonymous: Boolean,
+    val eventTime: String,
+    val thumbnailIndex: Int
+) {
     /**
      * 모든 필드 값들을 json 데이터로 변환해주는 메소드
      * @return JSONObject: 모든 필드들을 json 으로 변환한 객체 반환
@@ -29,10 +29,10 @@ data class RequestPostData(
         jsonParentObject.put("title", title)
         jsonParentObject.put("content", content)
 
-        jsonChildObject.put("region",location.region)
-        jsonChildObject.put("latitude",location.latitude)
-        jsonChildObject.put("longitude",location.longitude)
-        jsonParentObject.put("location",jsonChildObject)
+        jsonChildObject.put("address", location.address)
+        jsonChildObject.put("latitude", location.latitude)
+        jsonChildObject.put("longitude", location.longitude)
+        jsonParentObject.put("location", jsonChildObject)
 
         jsonParentObject.put("price", price)
         jsonParentObject.put("hashtagList", hashtagList)

--- a/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseMainFeed.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseMainFeed.kt
@@ -1,0 +1,24 @@
+package com.dope.breaking.model.response
+
+import com.dope.breaking.model.PostLocation
+import com.google.gson.annotations.SerializedName
+
+data class ResponseMainFeed(
+    @SerializedName("postId") val postId: Int,
+    @SerializedName("title") val title: String,
+    @SerializedName("location") val location: PostLocation,
+    @SerializedName("thumbnailImgURL") val thumbnailImgURL: String?,
+    @SerializedName("likeCount") val likeCount: Int,
+    @SerializedName("commentCount") val commentCount: Int,
+    @SerializedName("postType") val postType: String,
+    @SerializedName("viewCount") val viewCount: Int,
+    @SerializedName("user") val user: ResponseJwtUserInfo?,
+    @SerializedName("price") val price: Int,
+    @SerializedName("createdDate") val createdDate: String,
+    @SerializedName("isPurchasable") val isPurchasable: Boolean,
+    @SerializedName("isSold") val isSold: Boolean,
+    @SerializedName("isAnonymous") val isAnonymous: Boolean,
+    @SerializedName("isMyPost") val isMyPost: Boolean,
+    @SerializedName("isLiked") val isLiked: Boolean,
+    @SerializedName("isBookmarked") val isBookmarked: Boolean,
+)

--- a/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
@@ -103,7 +103,32 @@ interface RetrofitService {
      * @author Seunggun Sin
      */
     @GET("oauth2/validate-jwt")
-    suspend fun requestValidationJwt(@Header("Authorization") token: String): Response<ResponseExistLogin>
+    suspend fun requestValidationJwt(@Header("authorization") token: String): Response<ResponseExistLogin>
+
+    /**
+     * 메인 피드 리스트를 가져오는 요청
+     * @param token(String): Jwt 토큰 - 헤더 (옵션)
+     * @param lastPostId(Int): 마지막으로 가져온 post id (필수) (처음 요청 시에는 0 or null)
+     * @param contentsSize(Int): 가져올 게시글 개수 (필수)
+     * @param sortCategory(String?): 정렬 - 정렬 카테고리 (옵션)
+     * @param soldOption(String?): 필터 - 판매 상태 (옵션)
+     * @param dateFrom(String?): 필터 - 시작 날짜 (옵션)
+     * @param dateTo(String?): 필터 - 종료 날짜 (옵션)
+     * @param latestMin(Int?): 필터 - 최근 N분 (옵션)
+     * @response ResponseMainFeed 리스트
+     * @author Seunggun Sin
+     */
+    @GET("feed")
+    fun requestGetMainFeed(
+        @Header("authorization") token: String = "",
+        @Query("cursor") lastPostId: Int,
+        @Query("size") contentsSize: Int,
+        @Query("sort") sortCategory: String? = null,
+        @Query("sold-option") soldOption: String? = null,
+        @Query("date-from") dateFrom: String? = null,
+        @Query("date-to") dateTo: String? = null,
+        @Query("for-last-min") latestMin: Int? = null
+    ): Call<List<ResponseMainFeed>>
 
     /**
      * 유저의 고유 id 를 갖고 유저의 프로필 정보를 가져오는 요청 (회원가입이 되어있는 유저가 요청하는 경우)

--- a/Breaking/app/src/main/java/com/dope/breaking/util/DateUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/DateUtil.kt
@@ -1,0 +1,61 @@
+package com.dope.breaking.util
+
+import java.text.SimpleDateFormat
+import java.util.*
+
+class DateUtil {
+
+    /**
+     * 현재 날짜와 가져온 날짜의 차이를 적절한 범위에 해당하는 문자열을 반환하는 함수
+     * @param date(String): 문자열 형태의 날짜 데이터 (포맷: "yyyy-MM-ddTHH:mm:ss.fp" or "yyyy-MM-dd HH:mm:ss"")
+     * @return String: 현재와 날짜 차이를 적절한 범위에 해당하는 초/분/시/일 단위로 반환
+     * @author Seunggun Sin
+     * @since 2022-08-10
+     */
+    fun getTimeDiff(date: String): String {
+        if (!(date.length == 26 || date.length == 19)) { // 형식에 맞지 않으면 에러 리턴
+            return "-"
+        }
+        val today = Calendar.getInstance() // 오늘 날짜 가져오기
+        var newDate: String = date // 가져온 날짜를 가공할 변수
+
+        if (date.length == 26) { // 서버 기준 포맷이라면
+            newDate = date.replace("T", " ")
+            newDate = newDate.split(".")[0]
+        }
+
+        try {
+            val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss") // 형식 맞추기
+            val targetFormat = dateFormat.parse(newDate) // 기준 날짜 형식에 맞추기
+
+            var calcValue = (today.time.time - targetFormat.time) / 1000 // 초 단위로 날짜 차이 계산
+            /*
+                날짜 차이를 나누는 기준
+                / 1000: 초 단위
+                / 60 * 1000: 분 단위
+                / 60 * 60 * 1000: 시 단위
+                / 60 * 60 * 24 * 1000: 일 단위
+             */
+            var suffix: String = "초"
+            if (calcValue < 60) { // 60초 이내라면
+                suffix = "초" // 초 단위 사용
+            } else {
+                calcValue /= 60
+                if (calcValue < 60) { // 60분 이내라면
+                    suffix = "분" // 분 단위 사용
+                } else {
+                    calcValue /= 60
+                    if (calcValue < 24) { // 24시간 이내라면
+                        suffix = "시간" // 시 단위 사용
+                    } else {
+                        calcValue /= 24
+                        suffix = "일" // 일 단위 사용
+                    }
+                }
+            }
+            return "$calcValue$suffix 전" // 최종 가공한 날짜 차이 리턴
+        } catch (e: Exception) {
+            return "-" // 에러 값 리턴
+        }
+    }
+}

--- a/Breaking/app/src/main/res/drawable/chip_post_unsold_background.xml
+++ b/Breaking/app/src/main/res/drawable/chip_post_unsold_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="8dip" />
+    <solid android:color="@color/sign_up_user_type_unselected_color" />
+</shape>

--- a/Breaking/app/src/main/res/drawable/hashtag_item_background.xml
+++ b/Breaking/app/src/main/res/drawable/hashtag_item_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="6dip" />
+    <solid android:color="@color/sign_up_user_type_unselected_color" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/breaking_color" />
+</shape>

--- a/Breaking/app/src/main/res/drawable/ic_baseline_add_24.xml
+++ b/Breaking/app/src/main/res/drawable/ic_baseline_add_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:tint="@color/breaking_color"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+</vector>

--- a/Breaking/app/src/main/res/drawable/ic_baseline_filter_list_24.xml
+++ b/Breaking/app/src/main/res/drawable/ic_baseline_filter_list_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,18h4v-2h-4v2zM3,6v2h18L21,6L3,6zM6,13h12v-2L6,11v2z" />
+</vector>

--- a/Breaking/app/src/main/res/drawable/ic_baseline_search_24.xml
+++ b/Breaking/app/src/main/res/drawable/ic_baseline_search_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z" />
+</vector>

--- a/Breaking/app/src/main/res/drawable/ic_baseline_sort_24.xml
+++ b/Breaking/app/src/main/res/drawable/ic_baseline_sort_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="@color/breaking_color"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,18h6v-2L3,16v2zM3,6v2h18L21,6L3,6zM3,13h12v-2L3,11v2z" />
+</vector>

--- a/Breaking/app/src/main/res/drawable/ic_baseline_thumb_up_alt_24.xml
+++ b/Breaking/app/src/main/res/drawable/ic_baseline_thumb_up_alt_24.xml
@@ -1,5 +1,10 @@
-<vector android:height="28dp" android:tint="#000000"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="28dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M2,20h2c0.55,0 1,-0.45 1,-1v-9c0,-0.55 -0.45,-1 -1,-1L2,9v11zM21.83,12.88c0.11,-0.25 0.17,-0.52 0.17,-0.8L22,11c0,-1.1 -0.9,-2 -2,-2h-5.5l0.92,-4.65c0.05,-0.22 0.02,-0.46 -0.08,-0.66 -0.23,-0.45 -0.52,-0.86 -0.88,-1.22L14,2 7.59,8.41C7.21,8.79 7,9.3 7,9.83v7.84C7,18.95 8.05,20 9.34,20h8.11c0.7,0 1.36,-0.37 1.72,-0.97l2.66,-6.15z"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="26dp"
+    android:height="26dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M2,20h2c0.55,0 1,-0.45 1,-1v-9c0,-0.55 -0.45,-1 -1,-1L2,9v11zM21.83,12.88c0.11,-0.25 0.17,-0.52 0.17,-0.8L22,11c0,-1.1 -0.9,-2 -2,-2h-5.5l0.92,-4.65c0.05,-0.22 0.02,-0.46 -0.08,-0.66 -0.23,-0.45 -0.52,-0.86 -0.88,-1.22L14,2 7.59,8.41C7.21,8.79 7,9.3 7,9.83v7.84C7,18.95 8.05,20 9.34,20h8.11c0.7,0 1.36,-0.37 1.72,-0.97l2.66,-6.15z" />
 </vector>

--- a/Breaking/app/src/main/res/drawable/ic_baseline_tune_24.xml
+++ b/Breaking/app/src/main/res/drawable/ic_baseline_tune_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="@color/breaking_color"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,17v2h6v-2L3,17zM3,5v2h10L13,5L3,5zM13,21v-2h8v-2h-8v-2h-2v6h2zM7,9v2L3,11v2h4v2h2L9,9L7,9zM21,13v-2L11,11v2h10zM15,9h2L17,7h4L21,5h-4L17,3h-2v6z" />
+</vector>

--- a/Breaking/app/src/main/res/drawable/main_button_background.xml
+++ b/Breaking/app/src/main/res/drawable/main_button_background.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape>
+            <solid android:color="@color/sign_up_input_hint_text_color" />
+            <stroke android:width="1dp" android:color="@color/sign_up_input_hint_text_color" />
+        </shape>
+    </item>
+    <item android:state_pressed="false">
+        <shape>
+            <solid android:color="@color/white" />
+            <stroke android:width="1dp" android:color="@color/sign_up_input_hint_text_color" />
+        </shape>
+    </item>
+</selector>

--- a/Breaking/app/src/main/res/drawable/main_search_background.xml
+++ b/Breaking/app/src/main/res/drawable/main_search_background.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape>
+            <corners android:radius="6dip" />
+            <solid android:color="@color/breaking_bottom_clicked_color" />
+        </shape>
+    </item>
+    <item android:state_pressed="false">
+        <shape>
+            <corners android:radius="6dip" />
+            <solid android:color="@color/search_background_color" />
+        </shape>
+    </item>
+</selector>

--- a/Breaking/app/src/main/res/layout/activity_follow.xml
+++ b/Breaking/app/src/main/res/layout/activity_follow.xml
@@ -19,6 +19,7 @@
         android:layout_height="wrap_content">
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rcv_following"
+            android:overScrollMode="never"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:scrollbarAlwaysDrawVerticalTrack="true"

--- a/Breaking/app/src/main/res/layout/fragment_navi_home.xml
+++ b/Breaking/app/src/main/res/layout/fragment_navi_home.xml
@@ -6,45 +6,155 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <include layout="@layout/general_toolbar_layout" />
-
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".fragment.NaviChartFragment">
 
-        <TextView
-            android:id="@+id/tv_main"
+        <Button
+            android:id="@+id/btn_main_filter"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            android:background="@drawable/main_button_background"
+            android:drawableStart="@drawable/ic_baseline_tune_24"
+            android:padding="5dp"
+            android:text="@string/filter"
+            android:textSize="11sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintHeight_percent="0.04"
+            app:layout_constraintHorizontal_bias="0.05"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/top_divider"
+            app:layout_constraintVertical_bias="0.015" />
+
+        <Button
+            android:id="@+id/btn_main_sort"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            android:background="@drawable/main_button_background"
+            android:drawableStart="@drawable/ic_baseline_sort_24"
+            android:padding="5dp"
+            android:text="@string/latest_order"
+            android:textSize="11sp"
+            app:layout_constraintBottom_toBottomOf="@id/btn_main_filter"
+            app:layout_constraintHeight_percent="0.04"
+            app:layout_constraintHorizontal_bias="0.07"
+            app:layout_constraintLeft_toRightOf="@id/btn_main_filter"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="@id/btn_main_filter"
+            app:layout_constraintVertical_bias="0.02" />
+
+        <EditText
+            android:id="@+id/search_bar"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@drawable/main_search_background"
+            android:hint="@string/search_hint_text"
+            android:inputType="none"
+            android:textSize="13sp"
+            app:layout_constraintBottom_toBottomOf="@id/imgv_main_logo"
+            app:layout_constraintHeight_percent="0.04"
+            app:layout_constraintHorizontal_bias="0.85"
+            app:layout_constraintLeft_toRightOf="@id/imgv_main_logo"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="@id/imgv_main_logo"
+            app:layout_constraintWidth_percent="0.6" />
+
+        <ImageView
+            android:id="@+id/imgv_search_icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="브레이킹 메인 화면입니다."
+            android:background="@drawable/ic_baseline_search_24"
+            android:translationZ="10dp"
+            app:layout_constraintBottom_toBottomOf="@id/search_bar"
+            app:layout_constraintRight_toRightOf="@id/search_bar"
+            app:layout_constraintTop_toTopOf="@id/search_bar" />
+
+        <ImageView
+            android:id="@+id/imgv_main_logo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_breaking_logo2"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintHorizontal_bias="0.025"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.006" />
+
+        <View
+            android:id="@+id/top_divider"
+            android:layout_width="match_parent"
+            android:layout_height="0.7dp"
+            android:background="@color/gray"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/imgv_main_logo"
+            app:layout_constraintVertical_bias="0.005" />
+
+        <View
+            android:id="@+id/hashtag_top_divider"
+            android:layout_width="match_parent"
+            android:layout_height="0.8dp"
+            android:layout_marginTop="3dp"
+            android:layout_marginBottom="3dp"
+            android:background="@color/gray"
+            app:layout_constraintTop_toBottomOf="@id/btn_main_filter" />
+
+        <View
+            android:id="@+id/hashtag_bottom_divider"
+            android:layout_width="match_parent"
+            android:layout_height="0.8dp"
+            android:background="@color/gray"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@id/rcv_main_hashtag" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rcv_main_hashtag"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/hashtag_top_divider" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rcv_main_feed"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:overScrollMode="never"
+            android:scrollbarAlwaysDrawVerticalTrack="true"
+            android:scrollbarSize="5dp"
+            android:scrollbars="vertical"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/hashtag_bottom_divider"
+            app:layout_constraintVertical_bias="0.05" />
 
         <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
             android:id="@+id/fab_posting"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:gravity="center"
-            android:theme="@style/FormButton"
-            android:text="@string/post_home_btn"
-            android:textSize="11sp"
-            android:textColor="@color/breaking_color"
-            android:textStyle="bold"
-            android:textAppearance="@style/AppTextAppearance.Button"
             android:backgroundTint="@color/main_post_button_color"
-            app:strokeColor="@color/breaking_drawer_color"
-            app:layout_constraintWidth_percent="0.27"
-            app:layout_constraintHeight_percent="0.06"
-            app:layout_constraintTop_toTopOf="parent"
+            android:drawableLeft="@drawable/ic_baseline_add_24"
+            android:gravity="center_vertical"
+            android:text="@string/post_home_btn"
+            android:textAppearance="@style/AppTextAppearance.Button"
+            android:textColor="@color/breaking_color"
+            android:textSize="10sp"
+            android:textStyle="bold"
+            android:theme="@style/FormButton"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintVertical_bias="0.98"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHeight_percent="0.05"
             app:layout_constraintStart_toStartOf="parent"
-           />
-
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.98"
+            app:layout_constraintWidth_percent="0.28"
+            app:strokeColor="@color/breaking_drawer_color" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </LinearLayout>

--- a/Breaking/app/src/main/res/layout/item_hashtag_list.xml
+++ b/Breaking/app/src/main/res/layout/item_hashtag_list.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <Button
+        android:id="@+id/hash_tag_body"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:background="@drawable/hashtag_item_background"
+        android:gravity="bottom|center_horizontal"
+        android:text="# 강남 폭우"
+        android:textColor="@color/breaking_color"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintHeight_percent="1"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/img_btn_cancel" />
+
+    <ImageButton
+        android:id="@+id/img_btn_cancel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/ic_baseline_cancel_24"
+        app:layout_constraintBottom_toBottomOf="@id/hash_tag_body"
+        app:layout_constraintLeft_toRightOf="@id/hash_tag_body"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Breaking/app/src/main/res/layout/item_post_list.xml
+++ b/Breaking/app/src/main/res/layout/item_post_list.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="8dp">
+    android:padding="7dp">
 
     <ImageButton
         android:id="@+id/img_btn_post_more_menu"
@@ -14,99 +14,150 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.45" />
 
-    <ImageButton
+    <ImageView
         android:id="@+id/img_btn_post_like"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
         android:background="@drawable/ic_baseline_thumb_up_alt_24"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintHorizontal_bias="0.96"
+        app:layout_constraintHorizontal_bias="0.985"
         app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toLeftOf="@id/img_btn_post_bookmark"
+        app:layout_constraintRight_toLeftOf="@id/tv_post_like_count"
         app:layout_constraintTop_toBottomOf="@id/imgv_post_thumbnail"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="1" />
-
-    <ImageButton
-        android:id="@+id/img_btn_post_bookmark"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:adjustViewBounds="true"
-        android:background="@drawable/ic_baseline_bookmark_border_24"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="1"
-        app:layout_constraintWidth_percent="0.08" />
 
     <ImageView
         android:id="@+id/imgv_post_thumbnail"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintHeight_percent="0.94"
+        app:layout_constraintHeight_percent="0.945"
         app:layout_constraintHorizontal_bias="0.04"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/imgv_post_thumbnail"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_percent="0.315" />
+        app:layout_constraintWidth_percent="0.3" />
 
     <ImageView
         android:id="@+id/imgv_post_location_icon"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:background="@drawable/ic_baseline_location_on_24"
-        app:layout_constraintBottom_toBottomOf="@id/tv_post_location"
+        app:layout_constraintBottom_toBottomOf="@id/tv_post_time"
         app:layout_constraintLeft_toLeftOf="@id/tv_post_title"
-        app:layout_constraintTop_toTopOf="@id/tv_post_location"
+        app:layout_constraintTop_toTopOf="@id/tv_post_time"
         app:layout_constraintVertical_bias="0.6"
-        app:layout_constraintWidth_percent="0.05" />
+        app:layout_constraintWidth_percent="0.045" />
 
-    <LinearLayout
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="10dp"
-        android:orientation="horizontal"
-        app:layout_constraintBottom_toBottomOf="@id/imgv_post_thumbnail"
-        app:layout_constraintHeight_percent="0.15"
+    <TextView
+        android:id="@+id/tv_chip_exclusive"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="7dp"
+        android:layout_marginEnd="6dp"
+        android:background="@drawable/chip_post_exclusive_background"
+        android:gravity="center"
+        android:paddingStart="8dp"
+        android:paddingTop="2dp"
+        android:paddingEnd="8dp"
+        android:paddingBottom="2dp"
+        android:text="@string/exclusive_string"
+        android:textColor="@color/white"
+        android:textSize="10sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintHorizontal_chainStyle="packed"
         app:layout_constraintLeft_toLeftOf="@id/tv_post_price"
-        app:layout_constraintRight_toLeftOf="@id/img_btn_post_like"
+        app:layout_constraintRight_toLeftOf="@id/tv_chip_sold"
         app:layout_constraintTop_toBottomOf="@id/tv_post_price"
-        app:layout_constraintVertical_bias="1"
-        app:layout_constraintWidth_percent="0.35">
+        app:layout_constraintVertical_bias="0" />
 
-        <Button
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="15dp"
-            android:layout_weight="0.8"
-            android:background="@drawable/chip_post_exclusive_background"
-            android:text="단독"
-            android:textColor="@color/white"
-            android:textSize="10dp" />
+    <TextView
+        android:id="@+id/tv_chip_sold"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="7dp"
+        android:layout_marginEnd="6dp"
+        android:background="@drawable/chip_post_sold_background"
+        android:gravity="center"
+        android:paddingStart="8dp"
+        android:paddingTop="2dp"
+        android:paddingEnd="8dp"
+        android:paddingBottom="2dp"
+        android:text="@string/sold_string"
+        android:textColor="@color/white"
+        android:textSize="10sp"
+        android:textStyle="bold"
+        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintLeft_toRightOf="@id/tv_chip_exclusive"
+        app:layout_constraintRight_toLeftOf="@id/tv_chip_unsold"
+        app:layout_constraintTop_toBottomOf="@id/tv_post_price" />
 
-        <Button
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@drawable/chip_post_sold_background"
-            android:text="판매완료"
-            android:textColor="@color/white"
-            android:textSize="10dp" />
-    </LinearLayout>
+    <TextView
+
+        android:id="@+id/tv_chip_unsold"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="7dp"
+        android:background="@drawable/chip_post_unsold_background"
+        android:gravity="center"
+        android:paddingStart="8dp"
+        android:paddingTop="2dp"
+        android:paddingEnd="8dp"
+        android:paddingBottom="2dp"
+        android:text="@string/is_selling_string"
+        android:textColor="@color/breaking_color"
+        android:textSize="10sp"
+        android:textStyle="bold"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintLeft_toRightOf="@id/tv_chip_sold"
+        app:layout_constraintRight_toLeftOf="@id/img_btn_post_like"
+        app:layout_constraintTop_toBottomOf="@id/tv_post_price" />
+
+    <TextView
+        android:id="@+id/tv_post_nickname"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:text="닉네임 테스트요"
+        android:textColor="@color/black"
+        android:textSize="10sp"
+        android:textStyle="bold"
+        app:layout_constraintHorizontal_bias="0.1"
+        app:layout_constraintLeft_toRightOf="@id/tv_split_slash"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tv_post_time"
+        app:layout_constraintVertical_bias="0" />
+
+    <TextView
+        android:id="@+id/tv_split_slash"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="3dp"
+        android:layout_marginEnd="3dp"
+        android:text="@string/vertical_divider_string"
+        android:textColor="@color/black"
+        android:textSize="10sp"
+        app:layout_constraintBottom_toBottomOf="@id/tv_post_time"
+        app:layout_constraintHorizontal_bias="0.05"
+        app:layout_constraintLeft_toRightOf="@id/tv_post_time"
+        app:layout_constraintRight_toLeftOf="@id/tv_post_nickname"
+        app:layout_constraintTop_toTopOf="@id/tv_post_time" />
 
     <TextView
         android:id="@+id/tv_post_like_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="5"
+        android:text="500"
         android:textColor="@color/black"
-        android:textSize="11sp"
+        android:textSize="10sp"
         app:layout_constraintBottom_toBottomOf="@id/img_btn_post_like"
-        app:layout_constraintLeft_toRightOf="@id/img_btn_post_like"
-        app:layout_constraintRight_toLeftOf="@id/img_btn_post_bookmark"
+        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="@id/img_btn_post_like" />
 
     <TextView
@@ -117,9 +168,8 @@
         android:maxLines="2"
         android:text="A씨 사내 비리 폭로 제목테스트제목테스트제목테스트제목테스트제목테스트제목테스트제목테스트제목테스트..."
         android:textColor="@color/black"
-        android:textSize="14sp"
-        android:textStyle="bold"
-        app:layout_constraintHorizontal_bias="1"
+        android:textSize="13.5sp"
+        app:layout_constraintHorizontal_bias="0.9"
         app:layout_constraintLeft_toRightOf="@id/imgv_post_thumbnail"
         app:layout_constraintRight_toLeftOf="@id/img_btn_post_more_menu"
         app:layout_constraintTop_toTopOf="parent"
@@ -129,9 +179,9 @@
         android:id="@+id/tv_post_location"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="역삼동"
+        android:text="구로동"
         android:textColor="@color/breaking_color"
-        android:textSize="12sp"
+        android:textSize="10sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toRightOf="@id/imgv_post_location_icon"
         app:layout_constraintTop_toBottomOf="@id/tv_post_title"
@@ -141,10 +191,9 @@
         android:id="@+id/tv_post_time"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="3dp"
-        android:text="12분 전"
-        android:textSize="12sp"
-        app:layout_constraintBottom_toBottomOf="@id/tv_post_location"
+        android:layout_marginStart="2dp"
+        android:text="12시간 전"
+        android:textSize="10sp"
         app:layout_constraintLeft_toRightOf="@id/tv_split_dot"
         app:layout_constraintTop_toTopOf="@id/tv_post_location" />
 
@@ -152,8 +201,8 @@
         android:id="@+id/tv_split_dot"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="3dp"
-        android:text="·"
+        android:layout_marginStart="2dp"
+        android:text="@string/dot_divider"
         android:textColor="@color/black"
         android:textSize="14sp"
         app:layout_constraintBottom_toBottomOf="@id/tv_post_location"
@@ -170,9 +219,9 @@
         android:textSize="13sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintHorizontal_bias="0.03"
+        app:layout_constraintHorizontal_bias="0"
         app:layout_constraintLeft_toLeftOf="@id/tv_post_title"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_post_time"
-        app:layout_constraintVertical_bias="0.2" />
+        app:layout_constraintTop_toBottomOf="@id/tv_post_nickname"
+        app:layout_constraintVertical_bias="0.15" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Breaking/app/src/main/res/layout/progress_dialog_layout.xml
+++ b/Breaking/app/src/main/res/layout/progress_dialog_layout.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="match_parent">
 
     <ProgressBar
+        style="?android:attr/progressBarStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:indeterminateTint="@color/breaking_color"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        style="?android:attr/progressBarStyle"/>
+        app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Breaking/app/src/main/res/values/colors.xml
+++ b/Breaking/app/src/main/res/values/colors.xml
@@ -26,4 +26,5 @@
     <color name="follow_list_background_color">#F3F7FA</color>
     <color name="post_chip_exclusive_color">#777777</color>
     <color name="post_chip_sold_color">#B48F8F</color>
+    <color name="search_background_color">#F4F4F4</color>
 </resources>

--- a/Breaking/app/src/main/res/values/strings.xml
+++ b/Breaking/app/src/main/res/values/strings.xml
@@ -36,7 +36,7 @@
     <string name="follower">팔로워</string>
     <string name="written_post">작성 제보</string>
     <string name="setting_menu">설정</string>
-    <string name="post_home_btn">+ 제보하기</string>
+    <string name="post_home_btn">제보하기</string>
     <string name="post_register_image_video">사진/동영상 업로드</string>
     <string name="post_register_event_time">제보 발생 시간</string>
     <string name="post_register_location">위치</string>
@@ -56,4 +56,12 @@
     <string name="post_register_profile_type_secret">비공개</string>
     <string name="post_register_btn">제보하기</string>
     <string name="follow_remove">삭제</string>
+    <string name="is_selling_string">판매중</string>
+    <string name="exclusive_string">단독</string>
+    <string name="sold_string">판매완료</string>
+    <string name="vertical_divider_string">|</string>
+    <string name="dot_divider">·</string>
+    <string name="filter">필터</string>
+    <string name="latest_order">최신순</string>
+    <string name="search_hint_text">제보를 검색하세요.</string>
 </resources>


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #26

## 예상 리뷰 시간
20-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 모바일 키보드 오픈 시, 레이아웃이 압축되는 현상 해결(windowsoftinputmode)
- 게시글 아이템 레이아웃 수정
  - 닉네임 추가
  - 닉네임 추가에 따른 제약 관계 하드하게 조정
  - 하단 태그 추가 및 레이아웃 조정
  - 이미지 크기 조정
- 팔로우 리스트 오버스크롤 모드 삭제
- 메인 피드 요청 및 응답 메인 피드에 데이터 리스트를 view에 뿌려주기
- 메인 home 페이지 레이아웃 구현(툴바 제거 후, 커스터마이징을 위한 툴바를 가장한 view 추가)
- 채팅 fragment, 유저 페이지 post tab의 테스트 레이아웃 삭제
- 메인 home 페이지의 "게시글 추가" floating action button 레이아웃 조정
- 요청 시, Jwt 토큰이 들어가는 헤더의 key 값 소문자로 통일
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
- 16개의 게시글을 가져와 메인 페이지에 리스트로 각 아이템을 보여줌. (주소, 시간 차, 닉네임, 가격, 익명 여부, 글 유형, 판매 상태, 좋아요 수 등 view에 다 표시)
<img src="https://user-images.githubusercontent.com/54919474/183913504-98fa6cbd-a958-4110-b818-53285b89f2d2.png" width="35%" height="35%"/>

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
### 개발 이슈
- 게시글 아이템 레이아웃에 닉네임을 추가해야되는데, 이 좁은 공간에 어떻게 다 우겨 넣을 수 있을까에 대한 깊은 고민이 많았다.  이쁘게 보이려면 제일 적당한 곳이 `위치|시간`이 배치되어 있는 곳 옆에가 딱 적당했다. 
- 하지만 그곳에 배치하면 고려해야할 사항이 생긴다. 
  - 만약 주소가 길다면? + 만약 닉네임이 길다면? 에 대한 문제다 그렇게 되면 예상되는 결과가 우측 화면의 공간이 넘쳐나서 텍스트가 짤리게 된다. 그래서 주소, 시간, 닉네임의 공간을 균등하게 줘서 넘치면 주어진 공간(가로 길이)내로 넘치면 다음 줄로 넘어가도록 하려고 했지만, 이렇게 되면 서로 다 떨어져있게 되어 예쁘지가 않았다. 그래서 경우의 수를 생각해서 주소와 시간을 아무리 길어봤자 그렇게 길지 않을 것이라는 판단을 하여, 주소와 시간은 `wrap_content`로 주고 닉네임만 공간을 따로 지정해줘서 넘치면 다음줄로 넘어가도록 했다. 그리고 넘어갈 때 레이아웃 변동도 고려해야되기 때문에 주소, 시간, 닉네임, 가격간의 제약을 타이트하게 주었다. 

- 필터, 정렬, 검색, 해시태그 등등 메인 피드 상단에 배치해야될 것들을 어떻게 꾸밀지, 어떻게 배치할지 어떻게 구현할지 정말 고민이 많았다...

- 메인 피드 썸네일 이미지 비율 및 크기도 어떻게 할지 정말 참 고민이다.
 
- 게시글 레이아웃의 '단독', '판매완료', '판매중' 과 같은 태그 칩들을 보여줘야 하는데, 게시글의 유형에 따라 이 칩들은 각기 존재할 수도 있고 존재하지 않을 수도 있다. 그래서 그러한 처리를 위해 xml상에서는 다 보여주되, visibility 속성으로 조정할 계획이였다. visibility 속성을 사용하면서, 칩의 공간이 유연하게 숨긴 칩의 공간으로 이동할 수 있게끔 하고 싶었다. 
- 이 3개의 칩들을 서로 수평적으로 연결해두고, 가운데 칩을 숨기면, 연결이 끊기게 되서 어떻게 될지 예상이 안가는데, ConstraintLayout이 정말 파워풀한게 따로 처리를 하지 않아도 자동으로 사라진 칩의 공간을 연결된 칩이 대신 이동하게 된다.  (즉 사라진 칩의 연결관계를 옆에 있는 칩이 대신 가지게되는 것이다.) 이로써 이문제는 해결이 되었다. 
- 특정 view 내부의 끝부분에 아이콘을 추가할 때, 특히 ConstraintLayout을 사용할 때 아이콘의 right를 view의 right로 지정할 수가 있는데 이러면 아이콘이 뒤로 숨겨지는 효과가 있다. 그래서 이를 해결하기 위해 view를 앞으로 내보내기 위해 view의 속성 중 `trainsitionZ` 속성에 값을 줘서 위로 뜨게해주는 효과를 보여주어 아이콘이 앞으로 나올 수 있게 해준다. 
- 추가적으로 view의 `drawable{Direction}` 속성이 있는데, 보통 버튼에 주로 사용되며 텍스트와 이미지를 하나의 view안에 넣을 수 있게 해준다. 

### 다음으로 할 것
- 메인 피드 요청 & 응답 코드 모듈화 및 리팩토링
- 게시글 아이템 레이아웃에 "댓글 개수" 추가하기
- '좋아요' 수, '댓글' 수 숫자의 크기에 따른 텍스트 처리
- 필터링 및 정렬 옵션 구현하기
  - 상단 필터, 정렬 버튼 클릭 시 동작 구현
- 메인 피드 cursor & size 파라미터에 따른 요청 구현
- 메인 피드 각 아이템의 "더보기 아이콘" 팝업 메뉴 구현
- 메인 피드 요청에 따른 예외처리 및 defensive 처리 구현