### PR TITLE
hotfix: implement expired jwt token handling with refresh token & access token

### DIFF
--- a/Breaking/app/src/main/java/com/dope/breaking/EditProfileActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/EditProfileActivity.kt
@@ -104,7 +104,7 @@ class EditProfileActivity : AppCompatActivity() {
                 val statusMsg = binding.etStateMessage.text.toString()
                 val role = if (isRoleButtonSelected) "USER" else "PRESS"
 
-                val token = JwtTokenUtil(this).getTokenFromLocal() // 로컬에서 토큰 가져오기
+                val token = JwtTokenUtil(this).getAccessTokenFromLocal() // 로컬에서 토큰 가져오기
 
                 val progressDialog = DialogUtil().ProgressDialog(this)
                 progressDialog.showDialog() // 로딩 dialog 시작

--- a/Breaking/app/src/main/java/com/dope/breaking/FollowActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/FollowActivity.kt
@@ -34,7 +34,7 @@ class FollowActivity : AppCompatActivity() {
 
         CoroutineScope(Dispatchers.Main).launch {
             val requestToken =
-                ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(this@FollowActivity).getTokenFromLocal()
+                ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(this@FollowActivity).getAccessTokenFromLocal()
 
             try {
                 if (state) { // 팔로우 페이지라면

--- a/Breaking/app/src/main/java/com/dope/breaking/SignUpActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/SignUpActivity.kt
@@ -32,7 +32,6 @@ import com.dope.breaking.model.response.ResponseExistLogin
 import com.dope.breaking.util.DialogUtil
 import com.dope.breaking.util.ValueUtil
 
-
 class SignUpActivity : AppCompatActivity() {
     private val TAG = "SignUpActivity.kt" // Log Tag
 
@@ -167,13 +166,18 @@ class SignUpActivity : AppCompatActivity() {
             )
 
             val tokenUtil = JwtTokenUtil(applicationContext) // Jwt Util 객체 생성
-            val token = tokenUtil.getTokenFromResponse(responseHeaders) // 응답으로부터 Jwt 토큰 값 추출
+            val accessToken =
+                tokenUtil.getAccessTokenFromResponse(responseHeaders) // 응답으로부터 Jwt 엑세스 토큰 값 추출
+            val refreshToken =
+                tokenUtil.getRefreshTokenFromResponse(responseHeaders) // 응답으로부터 Jwt refresh 토큰 값 추출
 
-            if (token != null) { // 토큰이 존재하면
-                tokenUtil.setToken(token) // SharedPreferences 를 이용하여 Jwt 토큰을 로컬에 저장
+            if (accessToken != null && refreshToken != null) { // 토큰이 존재하면
+                tokenUtil.setAccessToken(accessToken) // SharedPreferences 를 이용하여 Jwt 토큰을 로컬에 저장
+                tokenUtil.setRefreshToken(refreshToken) // SharedPreferences 를 이용하여 refresh 토큰을 로컬에 저장
 
                 //회원가입 응답으로 받아온 토큰 값을 토대로 유저의 기본 정보 가져오는 요청
-                val userInfo = tokenUtil.validateJwtToken(ValueUtil.JWT_REQUEST_PREFIX + token)
+                val userInfo =
+                    tokenUtil.validateJwtToken(ValueUtil.JWT_REQUEST_PREFIX + accessToken)
                 moveToMainPage(userInfo) // 가져온 유저 정보 값을 가지고 메인 페이지로 이동하기
             } else {
                 // 존재하지 않는 Jwt 토큰 케이스에 대한 예외 던지기
@@ -185,9 +189,7 @@ class SignUpActivity : AppCompatActivity() {
                 this,
                 "회원가입 요청에 문제가 발생하였습니다.",
                 "확인"
-            ) {
-
-            }.show()
+            ).show()
             // 응답 에러에 대한 예외 처리하기
         } catch (e: MissingJwtTokenException) {
             // 토큰 값이 존재하지 않을 때에 대한 예외 처리하기
@@ -195,9 +197,7 @@ class SignUpActivity : AppCompatActivity() {
                 this,
                 "회원가입 정보를 불러오는데 실패하였습니다.",
                 "확인"
-            ) {
-
-            }.show()
+            ).show()
         }
     }
 

--- a/Breaking/app/src/main/java/com/dope/breaking/SplashActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/SplashActivity.kt
@@ -6,11 +6,13 @@ import android.os.Handler
 import android.os.Looper
 import androidx.appcompat.app.AppCompatActivity
 import com.dope.breaking.exception.ResponseErrorException
+import com.dope.breaking.model.response.ResponseExistLogin
 import com.dope.breaking.util.JwtTokenUtil
 import com.dope.breaking.util.ValueUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.json.JSONObject
 
 private const val DURATION: Long = 1500
 
@@ -27,33 +29,70 @@ class SplashActivity : AppCompatActivity() {
                 val jwtTokenUtil = JwtTokenUtil(applicationContext)
 
                 // 로컬에 Jwt 토큰이 저장되어 있다면
-                if (jwtTokenUtil.getTokenFromLocal() != "") {
+                if (jwtTokenUtil.getAccessTokenFromLocal() != "") {
                     // Jwt 토큰을 이용해 기본 유저 정보 요청
                     try {
                         val userData =
-                            jwtTokenUtil.validateJwtToken(ValueUtil.JWT_REQUEST_PREFIX + jwtTokenUtil.getTokenFromLocal())
+                            jwtTokenUtil.validateJwtToken(ValueUtil.JWT_REQUEST_PREFIX + jwtTokenUtil.getAccessTokenFromLocal())
 
-                        // 메인 페이지로 유저 데이터와 함께 이동
-                        val intent = Intent(applicationContext, MainActivity::class.java)
-                        intent.putExtra("userInfo", userData)
-                        intent.flags =
-                            Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-                        startActivity(intent)
-                        overridePendingTransition(R.anim.fade_in, R.anim.fade_out)
+                        moveToMainPage(userData) // 메인 페이지로 이동
                     } catch (e: ResponseErrorException) { // 토큰은 있는데 계정 정보가 없을 때 처리
-                        val intent = Intent(applicationContext, SignInActivity::class.java)
-                        startActivity(intent)
-                        overridePendingTransition(R.anim.fade_in, R.anim.fade_out)
-                        finish()
+                        val errorJson = JSONObject(e.message!!) // 에러 json 받아오기
+
+                        if (errorJson.getString("code") == "BSE002") { // 엑세스 토큰이 만료되었을 경우에 대한 에러 처리
+                            val result = jwtTokenUtil.reissueJwtToken(
+                                jwtTokenUtil.getAccessTokenFromLocal(),
+                                jwtTokenUtil.getRefreshTokenFromLocal()
+                            ) // 재발급 요청
+                            if (result) { // 재발급 및 새 토큰 저장 성공 시
+                                try {
+                                    val userData =
+                                        jwtTokenUtil.validateJwtToken(ValueUtil.JWT_REQUEST_PREFIX + jwtTokenUtil.getAccessTokenFromLocal())
+                                    // 유저 정보 요청
+                                    moveToMainPage(userData) // 메인 페이지로 이동
+                                } catch (e: ResponseErrorException) {
+                                    moveToLoginPage() // 자동로그인 실패시, 로그인 페이지로 이동
+                                }
+                            } else {
+                                moveToLoginPage() // 재발급 실패 시 로그인 페이지로 이동
+                            }
+                        } else { // 나머지 에러의 경우
+                            moveToLoginPage() // 로그인 페이지로 이동
+                        }
                     }
                 } else { // 로컬에 토큰이 저장되어 있지않다면
                     // 로그인 페이지로 이동
-                    val intent = Intent(applicationContext, SignInActivity::class.java)
-                    startActivity(intent)
-                    overridePendingTransition(R.anim.fade_in, R.anim.fade_out)
-                    finish()
+                    moveToLoginPage()
                 }
             }
         }, DURATION)
+    }
+
+    /**
+     * 메인 페이지로 이동하는 함수
+     * @param userData(ResponseExistLogin): 기존 유저가 로그인했을 경우 얻는 기본 유저 데이터 DTO
+     * @author Seunggun Sin
+     * @since 2022-08-17
+     */
+    private fun moveToMainPage(userData: ResponseExistLogin) {
+        // 메인 페이지로 유저 데이터와 함께 이동
+        val intent = Intent(applicationContext, MainActivity::class.java)
+        intent.putExtra("userInfo", userData)
+        intent.flags =
+            Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        startActivity(intent)
+        overridePendingTransition(R.anim.fade_in, R.anim.fade_out)
+    }
+
+    /**
+     * 로그인 페이지로 이동하는 함수
+     * @author Seunggun Sin
+     * @since 2022-08-17
+     */
+    private fun moveToLoginPage() {
+        val intent = Intent(applicationContext, SignInActivity::class.java)
+        startActivity(intent)
+        overridePendingTransition(R.anim.fade_in, R.anim.fade_out)
+        finish()
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/UserPageActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/UserPageActivity.kt
@@ -139,7 +139,7 @@ class UserPageActivity : AppCompatActivity() {
                 try {
                     progressDialog.showDialog() // 로딩 창 시작
                     val token =
-                        ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(this@UserPageActivity).getTokenFromLocal() // Jwt 토큰 값
+                        ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(this@UserPageActivity).getAccessTokenFromLocal() // Jwt 토큰 값
 
                     // 팔로우 중이라면 언팔로우 요청, 아니라면 팔로우 요청
                     val followResult = if (isFollowing) Follow().startUnFollowRequest(

--- a/Breaking/app/src/main/java/com/dope/breaking/adapter/FollowAdapter.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/adapter/FollowAdapter.kt
@@ -57,12 +57,12 @@ class FollowAdapter(
             if (data[position].userId == ResponseExistLogin.baseUserInfo?.userId) View.GONE else View.VISIBLE
 
         val token =
-            ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(context).getTokenFromLocal() // 요청 토큰
+            ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(context).getAccessTokenFromLocal() // 요청 토큰
 
         /*
         로그인 & 비로그인 유저 구분 / 내 팔로우(워) 리스트 & 다른 유저 팔로우(워) 리스트 구분 / 팔로우 & 팔로워 상태 구분
          */
-        if (ResponseExistLogin.baseUserInfo != null && JwtTokenUtil(context).getTokenFromLocal() != "") { // 로그인한 유저라면
+        if (ResponseExistLogin.baseUserInfo != null && JwtTokenUtil(context).getAccessTokenFromLocal() != "") { // 로그인한 유저라면
             if (currentUserId == ResponseExistLogin.baseUserInfo?.userId) { // 내 팔로우(워) 리스트인 경우
                 if (state) { // 팔로우 리스트
                     convertToFollowingState(holder.removeButton) // 팔로잉 버튼 상태로 전환

--- a/Breaking/app/src/main/java/com/dope/breaking/board/PostActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/board/PostActivity.kt
@@ -239,8 +239,9 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener,
         // 카카오 지도에서 제보 위치를 선택하고 제보 페이지로 다시 돌아오면
         locationActivityResult =
             registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-                if(it.resultCode == RESULT_OK) {
-                    locationData = it.data?.getSerializableExtra("locationData") as LocationList // 선택한 장소 위치 정보 받아와 할당
+                if (it.resultCode == RESULT_OK) {
+                    locationData =
+                        it.data?.getSerializableExtra("locationData") as LocationList // 선택한 장소 위치 정보 받아와 할당
                     binding.tvLocationShow.text = locationData.address // 선택한 위치 정보 표시
                 }
             }
@@ -267,17 +268,17 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener,
 
         /* 아래 3개는 현재 위치 불러오는 함수 */
         binding.tvLocationShow.setOnClickListener {
-            var intent = Intent(this,KakaoMapActivity::class.java)
+            var intent = Intent(this, KakaoMapActivity::class.java)
             locationActivityResult.launch(intent)
         }
 
         binding.tvLocationIcon.setOnClickListener {
-            var intent = Intent(this,KakaoMapActivity::class.java)
+            var intent = Intent(this, KakaoMapActivity::class.java)
             locationActivityResult.launch(intent)
         }
 
         binding.tvLocationIconText.setOnClickListener {
-            var intent = Intent(this,KakaoMapActivity::class.java)
+            var intent = Intent(this, KakaoMapActivity::class.java)
             locationActivityResult.launch(intent)
         }
 
@@ -356,8 +357,9 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener,
                         locationData.y,
                         locationData.x,
                         locationData.address.split(" ")[0],
-                        locationData.address.split(" ")[1]),
-                    binding.etPostPrice.text.toString().replace(",","").toInt(),
+                        locationData.address.split(" ")[1]
+                    ),
+                    binding.etPostPrice.text.toString().replace(",", "").toInt(),
                     hashTagList,
                     isPostTypeSelected,
                     isAnonymousSelected,
@@ -374,7 +376,7 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener,
                         requestPostData,
                         postBitmapList,
                         fileNameList,
-                        JwtTokenUtil(applicationContext).getTokenFromLocal() // 로컬에서 토큰 가져오기
+                        JwtTokenUtil(applicationContext).getAccessTokenFromLocal() // 로컬에서 토큰 가져오기
                     )
                     if (progressDialog.isShowing()) { // 로딩 다이얼로그 종료
                         progressDialog.dismissDialog()
@@ -427,7 +429,7 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener,
      * @since - 2022-08-10
      */
     @SuppressLint("MissingPermission") // 권한 재확인 안하기 위한 코드로, 코드 검사에서 제외할 부분을 미리 정의하는 것이라고 보면 됨.
-    private fun setCurrentLocation(){
+    private fun setCurrentLocation() {
         // 현재 위치 불러오기
         val lm: LocationManager = getSystemService(Context.LOCATION_SERVICE) as LocationManager
         val userNowLocation: Location? = lm.getLastKnownLocation(LocationManager.NETWORK_PROVIDER)
@@ -439,11 +441,15 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener,
         // 좌표를 바탕으로 현재 위치의 주소 불러오기 (Geocoder)
         val address = Geocoder(applicationContext).getFromLocation(uLatitude, uLongitude, 10)
         try {
-            if(address!=null){
-                if(address.isNullOrEmpty()) // 현재 위치 불러오기에 실패했다면
+            if (address != null) {
+                if (address.isNullOrEmpty()) // 현재 위치 불러오기에 실패했다면
                     throw FailedGetLocationException("현재 위치를 불러오는데 실패하였습니다.")
                 else {
-                    binding.tvLocationShow.setText((address as MutableList<Address>)[0].getAddressLine(0).substring(5)) // 선택한 위치 정보 표시
+                    binding.tvLocationShow.setText(
+                        (address as MutableList<Address>)[0].getAddressLine(
+                            0
+                        ).substring(5)
+                    ) // 선택한 위치 정보 표시
                     locationData = LocationList(
                         "", // 장소 이름
                         "", // 도로명
@@ -453,7 +459,7 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener,
                     )
                 }
             }
-        }catch (e: FailedGetLocationException){
+        } catch (e: FailedGetLocationException) {
             e.printStackTrace()
             DialogUtil().SingleDialog(
                 applicationContext,
@@ -610,7 +616,15 @@ class PostActivity : AppCompatActivity(), DatePickerDialog.OnDateSetListener,
         savedHour = hourOfDay
         savedMin = minute
         getDateTimeCalendar() // 현재 시간의 초도 가져오기 위함
-        binding.tvEventTimeClicked.text = "$savedYear" + String.format("년 %02d월 %02d일 ",savedMonth, savedDay) + String.format("%02d시 %02d분",savedHour, savedMin) // 서버에 넘겨줘야할 포맷 맞추기
-        eventTime = "$savedYear" + String.format("-%02d-%02d ",savedMonth, savedDay) + String.format("%02d:%02d:%02d",savedHour, savedMin, second)
+        binding.tvEventTimeClicked.text = "$savedYear" + String.format(
+            "년 %02d월 %02d일 ",
+            savedMonth,
+            savedDay
+        ) + String.format("%02d시 %02d분", savedHour, savedMin) // 서버에 넘겨줘야할 포맷 맞추기
+        eventTime = "$savedYear" + String.format(
+            "-%02d-%02d ",
+            savedMonth,
+            savedDay
+        ) + String.format("%02d:%02d:%02d", savedHour, savedMin, second)
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviHomeFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviHomeFragment.kt
@@ -51,7 +51,7 @@ class NaviHomeFragment : Fragment() {
             CoroutineScope(Dispatchers.Main).launch {
                 try {
                     val token =
-                        ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(requireContext()).getTokenFromLocal() // 토큰 가져오기
+                        ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(requireContext()).getAccessTokenFromLocal() // 토큰 가져오기
 
                     val list = postManager.startGetMainFeed(
                         0, // 마지막으로 받은 postId (최초 호출 시, 0 또는 null 로 지정)
@@ -112,7 +112,7 @@ class NaviHomeFragment : Fragment() {
 
             try {
                 val token =
-                    ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(requireContext()).getTokenFromLocal()
+                    ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(requireContext()).getAccessTokenFromLocal()
                 val list = postManager.startGetMainFeed(
                     0,
                     ValueUtil.FEED_SIZE,

--- a/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseExistLogin.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseExistLogin.kt
@@ -14,7 +14,7 @@ data class ResponseExistLogin(
         var baseUserInfo: ResponseExistLogin? = null
         fun convertJsonToObject(jsonObject: JSONObject): ResponseExistLogin {
             return ResponseExistLogin(
-                jsonObject["userId"] as Long,
+                (jsonObject["userId"] as Int).toLong(),
                 jsonObject["profileImgURL"] as String,
                 jsonObject["nickname"] as String,
                 jsonObject["balance"] as Int

--- a/Breaking/app/src/main/java/com/dope/breaking/oauth/GoogleLogin.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/oauth/GoogleLogin.kt
@@ -77,8 +77,13 @@ class GoogleLogin(private val context: Context) {
                     )
                 ) {
                     // 로컬에 저장된 토큰이 없다면 저장하기
-                    if (jwtTokenUtil.getTokenFromLocal() == "") {
-                        jwtTokenUtil.setToken(jwtTokenUtil.getTokenFromResponse(validationResponse.headers())!!)
+                    if (jwtTokenUtil.getAccessTokenFromLocal() == "") {
+                        jwtTokenUtil.setAccessToken(
+                            jwtTokenUtil.getAccessTokenFromResponse(validationResponse.headers())!!
+                        ) // 엑세스 토큰 로컬에 저장
+                        jwtTokenUtil.setRefreshToken(
+                            jwtTokenUtil.getRefreshTokenFromResponse(validationResponse.headers())!!
+                        ) // 리프레시 토큰 로컬에 저장
                     }
                     true
                 } else
@@ -160,6 +165,7 @@ class GoogleLogin(private val context: Context) {
             */
             val response =
                 service.requestGoogleLogin(
+                    System.getProperty("http.agent"),
                     RequestGoogleToken(
                         idToken,
                         accessToken
@@ -167,7 +173,11 @@ class GoogleLogin(private val context: Context) {
                 ).execute()
             // 먼저 예기치 못한 응답 코드에 대해서 예외 발생 시키기
             if (response.code() != 406 && response.code() >= 400) {
-                throw ResponseErrorException("요청에 실패하였습니다. code: ${response.code()}\nerror: ${response.errorBody()}")
+                throw ResponseErrorException(
+                    "요청에 실패하였습니다. code: ${response.code()}\nerror: ${
+                        response.errorBody()?.string()
+                    }"
+                )
             }
             // 응답으로 온 json string 을 json object 로 변환
             val responseJson = JSONObject(response.body().toString())

--- a/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
@@ -21,7 +21,10 @@ interface RetrofitService {
     @since - 2022-07-05 | 2022-07-20
      **/
     @POST("oauth2/sign-in/kakao")
-    fun requestKakaoLogin(@Body tokens: RequestKakaoToken): Call<JsonElement>
+    fun requestKakaoLogin(
+        @Header("User-Agent") userAgent: String,
+        @Body tokens: RequestKakaoToken
+    ): Call<JsonElement>
 
     /**
      * 회원가입 시 전화번호 검증 요청 메소드
@@ -81,22 +84,27 @@ interface RetrofitService {
      */
     @GET("v2/local/search/keyword.json")
     fun getSearchKeyword(
-        @Header("Authorization") key: String,     // 카카오 Rest API 인증키 [필수]
+        @Header("authorization") key: String,     // 카카오 Rest API 인증키 [필수]
         @Query("query") query: String,            // 검색을 원하는 질의어 [필수]
         @Query("page") page: Int                  // 결과 페이지 번호 [옵션]
     ): Call<ResponseLocationSearch>
 
     /**
      * 구글 로그인 토큰 검증 요청 메소드
+     * @param userAgent: 안드로이드 플랫폼 user-agent 헤더 값
      * @request RequestGoogleToken
      * @response ResponseLogin
      * @author Seunggun Sin
      */
     @POST("oauth2/sign-in/google")
-    fun requestGoogleLogin(@Body tokens: RequestGoogleToken): Call<JsonElement>
+    fun requestGoogleLogin(
+        @Header("User-Agent") userAgent: String,
+        @Body tokens: RequestGoogleToken
+    ): Call<JsonElement>
 
     /**
      * 최종 회원가입 요청 메소드 - Multipart 요청
+     * @param userAgent: 안드로이드 플랫폼 user-agent 헤더 값
      * @param image(MultipartBody.Part): 이미지가 담긴 multi form 요청 body (key=profileImg)
      * @param data(RequestBody): 나머지 텍스트 필드  값이 담긴 요청 body (key=signUpRequest)
      * @response Unit: 응답 body 자체는 중요 x, Jwt 토큰을 위한 헤더 값만 필요
@@ -105,6 +113,7 @@ interface RetrofitService {
     @Multipart
     @POST("oauth2/sign-up")
     suspend fun requestSignUp(
+        @Header("User-Agent") userAgent: String,
         @Part image: MultipartBody.Part,
         @Part("signUpRequest") data: RequestBody
     ): Response<Unit>
@@ -117,6 +126,20 @@ interface RetrofitService {
      */
     @GET("oauth2/validate-jwt")
     suspend fun requestValidationJwt(@Header("authorization") token: String): Response<ResponseExistLogin>
+
+    /**
+     * 엑세스 토큰 만료 시, 토큰을 재발급하기 위한 요청
+     * @param userAgent: 안드로이드 플랫폼 user-agent 헤더 값
+     * @param accessToken: 로컬에 저장된 엑세스 토큰
+     * @param refreshToken: 로컬에 저장된 리프레시 토큰
+     * @response: 성공 시 body 없음. 에러 발생 시 json element로 받음
+     */
+    @GET("reissue")
+    suspend fun requestReissueJwtToken(
+        @Header("User-Agent") userAgent: String,
+        @Header("authorization") accessToken: String,
+        @Header("authorization-refresh") refreshToken: String
+    ): Response<JsonElement>
 
     /**
      * 메인 피드 리스트를 가져오는 요청

--- a/Breaking/app/src/main/java/com/dope/breaking/signup/Account.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/signup/Account.kt
@@ -50,7 +50,7 @@ class Account {
             RequestBody.create(MediaType.parse("text/plain"), inputData.convertJsonToString())
 
         // retrofit 이용하여 회원가입 요청
-        val response = service.requestSignUp(imgFile, data)
+        val response = service.requestSignUp(System.getProperty("http.agent"), imgFile, data)
 
         if (response.code() in 200..299) { // 요청이 성공적이라면
             return response.headers() // 응답의 헤더 객체 리턴

--- a/Breaking/app/src/main/java/com/dope/breaking/user/UserProfile.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/user/UserProfile.kt
@@ -71,7 +71,7 @@ class UserProfile(private val activity: Activity) {
      */
     fun getUserDetailInfo() {
         val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
-        val token = JwtTokenUtil(activity).getTokenFromLocal() // 로컬에 저장된 토큰 가져오기
+        val token = JwtTokenUtil(activity).getAccessTokenFromLocal() // 로컬에 저장된 토큰 가져오기
         if (token.isNotEmpty())
         // 기존 유저 데이터 요청
             service.requestDetailUserInfo(ValueUtil.JWT_REQUEST_PREFIX + token)
@@ -118,7 +118,7 @@ class UserProfile(private val activity: Activity) {
     suspend fun getUserProfileInfo(userId: Long): User {
         val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
         val token =
-            ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(activity).getTokenFromLocal() // 로컬에 저장된 토큰 가져오기
+            ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(activity).getAccessTokenFromLocal() // 로컬에 저장된 토큰 가져오기
         if (token.isNotEmpty()) {
             val response =
                 service.requestUserProfileInfo(userId, token)

--- a/Breaking/app/src/main/java/com/dope/breaking/util/JwtTokenUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/JwtTokenUtil.kt
@@ -18,13 +18,23 @@ class JwtTokenUtil(context: Context) {
     private val prefUtil = PreferenceUtil(context, fileName) // SharedPreferences Util 객체
 
     /**
-     * 로컬 파일, 즉, SharedPreferences 로부터 토큰 값을 가져오는 메소드
-     * @return String: 로컬에 저장된 jwt 토큰 값 리턴, 없다면 빈 문자열 리턴
+     * 로컬 파일, 즉, SharedPreferences 로부터 (엑세스)토큰 값을 가져오는 메소드
+     * @return String: 로컬에 저장된 (엑세스) jwt 토큰 값 리턴, 없다면 빈 문자열 리턴
      * @author Seunggun Sin
      * @since 2022-07-09 | 2022-07-28
      */
-    fun getTokenFromLocal(): String {
+    fun getAccessTokenFromLocal(): String {
         return prefUtil.getString("token", "")
+    }
+
+    /**
+     * 로컬 파일, 즉, SharedPreferences 로부터 (refresh) 토큰 값을 가져오는 메소드
+     * @return String: 로컬에 저장된 (refresh) jwt 토큰 값 리턴, 없다면 빈 문자열 리턴
+     * @author Seunggun SIn
+     * @since 2022-08-17
+     */
+    fun getRefreshTokenFromLocal(): String {
+        return prefUtil.getString("refresh-token", "")
     }
 
     /**
@@ -47,11 +57,34 @@ class JwtTokenUtil(context: Context) {
                 throw ResponseErrorException("응답 Body가 존재하지 않습니다!")
             }
         } else {
-            throw ResponseErrorException(
-                "요청에 실패하였습니다. code: ${response.code()}\nerror: ${
-                    response.errorBody()?.string()
-                }"
-            )
+            throw ResponseErrorException("${response.errorBody()?.string()}")
+        }
+    }
+
+    /**
+     * Jwt 토큰을 재발급을 하는 요청 (기존에 저장되있는 토큰으로 요청 후, 새로 발급된 토큰을 저장)
+     * @param accessToken(String): 로컬에 저장되어 있는 엑세스 토큰
+     * @param refreshToken(String): 로컬에 저장되어 있는 리프레시 토큰
+     * @return 재발급에 성공하면 true, 실패하면 false
+     * @author Seunggun Sin
+     * @since 2022-08-17
+     */
+    suspend fun reissueJwtToken(accessToken: String, refreshToken: String): Boolean {
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+
+        val response = service.requestReissueJwtToken(
+            System.getProperty("http.agent"),
+            accessToken,
+            refreshToken
+        ) // 재발급 요청
+
+        return if (response.code() in 200..299) {
+            val headers = response.headers()
+            setAccessToken(headers[ValueUtil.JWT_HEADER_KEY]!!) // 로컬에 엑세스 토큰 저장
+            setRefreshToken(headers[ValueUtil.REFRESH_JWT_HEADER_KEY]!!) // 로컬에 리프레시 토큰 저장
+            true
+        } else {
+            false
         }
     }
 
@@ -62,19 +95,40 @@ class JwtTokenUtil(context: Context) {
      * @author Seunggun Sin
      * @since 2022-07-09
      */
-    fun getTokenFromResponse(headers: Headers): String? {
+    fun getAccessTokenFromResponse(headers: Headers): String? {
         return headers[ValueUtil.JWT_HEADER_KEY]
     }
 
     /**
-     * 로컬에 토큰 값을 저장하는 메소드 (key=token)
+     * Http 요청의 응답의 헤더로부터 Jwt 토큰 값을 가져오는 메소드
+     * @param headers(Headers): 응답 헤더 객체
+     * @return String?: 헤더에 담긴 refresh-jwt 토큰 값 리턴, 없다면 null 리턴
+     * @author Seunggun Sin
+     * @since 2022-08-17
+     */
+    fun getRefreshTokenFromResponse(headers: Headers): String? {
+        return headers[ValueUtil.REFRESH_JWT_HEADER_KEY]
+    }
+
+    /**
+     * 로컬에 (엑세스)토큰 값을 저장하는 메소드 (key=token)
      * @param token(String): 저장하고자 하는 jwt 토큰 문자열
      * @return None
      * @author Seunggun Sin
-     * @since 2022-07-09
+     * @since 2022-07-09 | 2022-08-17
      */
-    fun setToken(token: String) {
+    fun setAccessToken(token: String) {
         prefUtil.setString("token", token)
+    }
+
+    /**
+     * 로컬에 (refresh)토큰 값을 저장하는 메소드(key=refresh-token)
+     * @param token(String): 저장하고자 하는 refresh jwt 토큰 문자열
+     * @author Seunggun Sin
+     * @since 2022-08-17
+     */
+    fun setRefreshToken(token: String) {
+        prefUtil.setString("refresh-token", token)
     }
 
     /**

--- a/Breaking/app/src/main/java/com/dope/breaking/util/ValueUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/ValueUtil.kt
@@ -15,6 +15,7 @@ class ValueUtil {
         const val MULTIPART_PROFILE_KEY = "profileImg" // multi part 프로필 요청에 대한 key 이름
         const val MULTIPART_POST_KEY = "mediaList"  // multi part 게시글 요청에 대한 key 이름
         const val JWT_HEADER_KEY = "authorization" // JWT 토큰 검증을 위한 헤더 키 값
+        const val REFRESH_JWT_HEADER_KEY = "authorization-refresh" // refresh token 키 값
         const val JWT_REQUEST_PREFIX = "Bearer " // Jwt 토큰을 헤더에 넣고 요청할 때 필요한 접두사
         const val FILTER_DATE_FORMAT_SUFFIX = "T00:00" // 피드 요청 시 "기간" 필터의 날짜 형식에 대한 접미사
         const val FEED_SIZE = 10 // 피드 요청마다 가져올 게시글 개수


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #70 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 토큰 재발급 요청 추가
  - Splash에서 자동 로그인에서 토큰 검증할 때, 토큰이 만료되었으면 새로 재발급 받고 토큰 로컬에 새로 저장
  - 기존 access token만 저장한 것을 로그인 시 헤더로 받아오는 refresh token도 로컬에 저장
- 로그인/회원가입/토큰 재발급 시 안드로이드의 User-Agent 헤더 추가
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
x
## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 긴급하게 필요하여 핫픽스합니다. (이 기능 없이는 어떤 요청도 불가능하여..)
- 토큰 만료 테스트는 불가능하여 검증이 불가능합니다. 
- 중간 프로세스가 빠진게 있을 수 있습니다. 우선 급한불부터 끄고 추후에 문제 발생 시 수정하도록 하겠습니다. 