### PR TITLE
fix: implement follow list as a pagination

### DIFF
--- a/Breaking/app/src/main/java/com/dope/breaking/FollowActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/FollowActivity.kt
@@ -3,8 +3,11 @@ package com.dope.breaking
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.MenuItem
+import android.view.View
+import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.dope.breaking.adapter.FollowAdapter
 import com.dope.breaking.exception.ResponseErrorException
@@ -19,8 +22,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class FollowActivity : AppCompatActivity() {
-    private val data = mutableListOf<FollowData>() // 팔로우 목록 저장하는 리스트
+    private val followList = mutableListOf<FollowData?>() // 팔로우 목록 저장하는 리스트
     private var userId: Long = 0
+    private val follow = Follow() // 팔로우 관련 기능 객체 생성
+    private var isLoading = false // 로딩 중 판단
+    private var isObtainedAll = false // 더 이상 얻을 리스트 있는지 판단
+    private lateinit var followAdapter: FollowAdapter // 팔로우 리스트 어댑터
+    private val cursorList = mutableListOf<Int>()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         /*
@@ -30,36 +38,107 @@ class FollowActivity : AppCompatActivity() {
          */
         val state = intent.getBooleanExtra("state", true)
         userId = intent.getLongExtra("userId", 0) // 리스트를 보여주고자 하는 대상의 고유 id
-        val follow = Follow() // 팔로우 관련 기능 객체 생성
+        val requestToken =
+            ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(this).getAccessTokenFromLocal()
 
-        CoroutineScope(Dispatchers.Main).launch {
-            val requestToken =
-                ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(this@FollowActivity).getAccessTokenFromLocal()
+        setContentView(R.layout.activity_follow) // 목록 레이아웃 처리
 
-            try {
-                if (state) { // 팔로우 페이지라면
-                    val list = follow.startGetFollowingList(requestToken, userId) // 팔로잉 리스트 요청
-                    val size = list.size // 리스트 크기
-                    showFollowList(size, state, list) // 가져온 리스트를 화면에 보여주기
-                } else { // 팔로워 페이지라면
-                    val list = follow.startGetFollowerList(requestToken, userId) // 팔로워 리스트 요청
-                    val size = list.size // 리스트 크기
-                    showFollowList(size, state, list) // 가져온 리스트를 화면에 보여주기
-                }
-            } catch (e: ResponseErrorException) {
-                DialogUtil().SingleDialog(
-                    this@FollowActivity,
-                    "요청에 문제가 발생하였습니다.",
-                    "확인"
-                ).show()
-            } catch (e: Exception) {
-                e.printStackTrace()
-                DialogUtil().SingleDialog(
-                    this@FollowActivity,
-                    "예기치 못한 문제가 발생하였습니다.",
-                    "확인"
-                ).show()
+        val progress = findViewById<ProgressBar>(R.id.progressbar_loading)
+        val recyclerView = findViewById<RecyclerView>(R.id.rcv_following)
+
+        followAdapter = FollowAdapter(this, followList, state, userId) // 초기 어댑터 지정
+
+        /*
+            최초 팔로우 리스트 요청
+         */
+        processGetFollowList(state, 0, requestToken, {
+            // 초기 로딩 처리
+            progress.visibility = View.VISIBLE
+            recyclerView.visibility = View.GONE
+        }, { it ->
+            followAdapter.addItems(it) // 리스트에 추가하기
+            followList.forEach {
+                cursorList.add(it!!.cursorId)
             }
+
+            if (followList.size == 0) { // 목록 없을 때
+                handleEmptyList(state) // 빈 레이아웃 처리하기
+            } else {
+                setToolbar(state) // 툴바 설정
+                extractMyselfItem() // 본인이 있다면 최상단으로 올리기
+            }
+            recyclerView.adapter = followAdapter // 리사이클러 뷰에 어댑터 설정
+
+            // 로딩 처리 종료
+            progress.visibility = View.GONE
+            recyclerView.visibility = View.VISIBLE
+
+            /*
+                스크롤 이벤트 지정
+             */
+            recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+                override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                    super.onScrollStateChanged(recyclerView, newState)
+
+                    val lastIndex =
+                        (recyclerView.layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition()
+
+                    if (lastIndex == recyclerView.adapter!!.itemCount - 1 && newState == 2 && !isObtainedAll && !isLoading) {
+                        processGetFollowList(state,
+                            followList[lastIndex]!!.cursorId, // 마지막 인덱스
+                            requestToken,
+                            {
+                                followAdapter.addItem(null) // 로딩 아이템 추가
+                                isLoading = true // 로딩 상태 on
+                            },
+                            { it2 ->
+                                if (it2.size < ValueUtil.FOLLOW_SIZE) { // 리스트가 비어있다면
+                                    followAdapter.removeLast() // 먼저 로딩 아이템 제거
+                                    if (it2.isNotEmpty()) {
+                                        followAdapter.addItems(it2) // 받아온 리스트 추가
+                                    }
+                                    isObtainedAll = true // 더 이상 받아올 피드가 없다는 상태로 전환
+                                } else { // 리스트가 있다면
+                                    followAdapter.removeLast() // 먼저 로딩 아이템 제거
+                                    followAdapter.addItems(it2) // 받아온 리스트 추가
+                                }
+
+                                extractMyselfItem() // 새로 업데이트할 때마다 본인 아이템 있는 경우 최상단으로 옮기기
+                                isLoading = false // 로딩 상태 off
+                            },
+                            {
+                                DialogUtil().SingleDialog(
+                                    this@FollowActivity,
+                                    "요청에 문제가 발생하였습니다.",
+                                    "확인"
+                                ).show()
+                            })
+                    }
+                }
+            })
+        }, {
+            DialogUtil().SingleDialog(
+                this@FollowActivity,
+                "요청에 문제가 발생하였습니다.",
+                "확인"
+            ).show()
+        })
+    }
+
+    /**
+     * 현재 리스트에서 본인이 포함되어있다면 맨 상단으로 이동시키는 함수
+     * @author Seunggun
+     * @since 2022-08-18
+     */
+    private fun extractMyselfItem() {
+        var i = 0
+        for (followData in followAdapter.data) {
+            if (followData!!.userId == ResponseExistLogin.baseUserInfo?.userId) {
+                followAdapter.removeItem(followData) // 현재 데이터 제거
+                followAdapter.addItemIndex(0, followData) // 첫번째 인덱스에 추가
+                break
+            }
+            i++
         }
     }
 
@@ -92,47 +171,36 @@ class FollowActivity : AppCompatActivity() {
     }
 
     /**
-     * 가져온 리스트를 RecyclerView 의 어댑터에 적용하기
-     * @param recyclerView(RecyclerView): 화면에 보여줄 recyclerView
-     * @param list(List<FollowData>): 응답으로 받아온 팔로우(워) 목록 리스트
-     * @param state(Boolean): 팔로잉(true) or 팔로워(false) 구분
+     * 팔로우(워) 리스트를 얻는 요청 프로세스 함수
+     * @param state(Boolean): 팔로우인지, 팔로워 리스트인지 판단
+     * @param cursorId(Int): 마지막으로 요청한 리스트의 마지막 인덱스
+     * @param token(String): Jwt 엑세스 토큰
+     * @param init(() -> Unit): 요청전 초기 실행 함수
+     * @param last((List<FollowData>) -> Unit): 요청 후 실행할 함수
+     * @param error((ResponseErrorException) -> Unit): 에러 발생 시 실행 함수
      * @author Seunggun Sin
-     * @since 2022-07-28 | 2022-07-31
+     * @since 2022-08-18
      */
-    private fun adaptList(recyclerView: RecyclerView, list: List<FollowData>, state: Boolean) {
-        list.forEach { element ->
-            data.add(element) // mutable 리스트에 아이템 추가
-        }
-        /*
-           특정 유저의 팔로우 or 팔로워 리스트에 내가 포함되어 있을 때 첫번째 인덱스로 이동
-         */
-        for (followData in data) {
-            if (followData.userId == ResponseExistLogin.baseUserInfo?.userId) {
-                data.remove(followData) // 현재 데이터 제거
-                data.add(0, followData) // 첫번째 인덱스에 추가
-                break
-            }
-        }
-        val followAdapter = FollowAdapter(this, data, state, userId)
-        recyclerView.adapter = followAdapter // recyclerView 에 어댑터 적용
-    }
+    private fun processGetFollowList(
+        state: Boolean,
+        cursorId: Int,
+        token: String,
+        init: () -> Unit,
+        last: (List<FollowData>) -> Unit,
+        error: (ResponseErrorException) -> Unit
+    ) {
+        CoroutineScope(Dispatchers.Main).launch {
+            init() // 초기 함수 실행
+            try {
+                val responseList = if (state)
+                    follow.startGetFollowingList(cursorId, token, userId)
+                else
+                    follow.startGetFollowerList(cursorId, token, userId)
 
-    /**
-     * 가져온 리스트를 바탕으로 화면처리하기 (목록 화면, 빈 화면 처리)
-     * @param size(Int): 리스트의 사이즈
-     * @param state(Boolean): 팔로우 리스트(true)인지 팔로워 리스트(false)인지 구분
-     * @param list(List<FollowData>): 응답으로 받아온 팔로우(워) 목록 리스트
-     * @author Seunggun Sin
-     * @since 2022-07-28
-     */
-    private fun showFollowList(size: Int, state: Boolean, list: List<FollowData>) {
-        if (size == 0) { // 목록 없을 때
-            handleEmptyList(state) // 빈 레이아웃 처리하기
-        } else {
-            setContentView(R.layout.activity_follow) // 목록 레이아웃 처리
-            setToolbar(state) // 툴바 설정
-            val recyclerView = findViewById<RecyclerView>(R.id.rcv_following)
-            adaptList(recyclerView, list, state) // recyclerView 에 적용하기
+                last(responseList) // 요청 후 함수 호출
+            } catch (e: ResponseErrorException) {
+                error(e) // 에러 함수 호출
+            }
         }
     }
 

--- a/Breaking/app/src/main/java/com/dope/breaking/adapter/FeedAdapter.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/adapter/FeedAdapter.kt
@@ -22,12 +22,10 @@ class FeedAdapter(
     private val context: Context,
     var data: MutableList<ResponseMainFeed?>
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-    private val VIEW_TYPE_ITEM = 0 // 일반 아이템에 대한 레이아웃 view type
-    private val VIEW_TYPE_LOADING = 1 // 로딩 아이템에 대한 레이아웃 view type
     private val decimalFormat = DecimalFormat("#,###") // 숫자 콤마 포맷을 위한 클래스
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        return if (viewType == VIEW_TYPE_ITEM) {
+        return if (viewType == ValueUtil.VIEW_TYPE_ITEM) {
             val view = LayoutInflater.from(context).inflate(R.layout.item_post_list, parent, false)
             ItemViewHolder(view)
         } else {
@@ -53,7 +51,7 @@ class FeedAdapter(
      */
     fun addItem(item: ResponseMainFeed?) {
         data.add(item)
-        notifyDataSetChanged()
+        notifyItemInserted(itemCount)
     }
 
     /**
@@ -63,7 +61,7 @@ class FeedAdapter(
      */
     fun clearList() {
         data.clear()
-        notifyDataSetChanged()
+        notifyItemRangeRemoved(0, itemCount)
     }
 
     /**
@@ -74,7 +72,7 @@ class FeedAdapter(
      */
     fun addItems(items: List<ResponseMainFeed>) {
         data.addAll(items)
-        notifyDataSetChanged()
+        notifyItemRangeInserted(itemCount, items.size)
     }
 
     /**
@@ -91,7 +89,7 @@ class FeedAdapter(
      * 아이템 view type 을 가져옴
      */
     override fun getItemViewType(position: Int): Int {
-        return if (data[position] == null) VIEW_TYPE_LOADING else VIEW_TYPE_ITEM
+        return if (data[position] == null) ValueUtil.VIEW_TYPE_LOADING else ValueUtil.VIEW_TYPE_ITEM
     }
 
     inner class ItemViewHolder(view: View) : RecyclerView.ViewHolder(view) {

--- a/Breaking/app/src/main/java/com/dope/breaking/adapter/FollowAdapter.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/adapter/FollowAdapter.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageView
+import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
@@ -25,71 +26,97 @@ import kotlinx.coroutines.launch
 /**
  * 팔로우(워) 리스트 어댑터
  * @param context(Context): 리스트 호출하는 컨텍스트
- * @param data(MutableList<FollowData>): 응답으로 받아온 팔로우(워) 데이터 리스트
+ * @param data(MutableList<FollowData?>): 응답으로 받아온 팔로우(워) 데이터 리스트
  * @param state(Boolean): 팔로우 리스트인지 팔로워 리스트인지 구분
  * @param currentUserId(Long): 팔로우(워) 리스트의 대상
  */
 class FollowAdapter(
     private val context: Context,
-    var data: MutableList<FollowData>,
+    var data: MutableList<FollowData?>,
     private val state: Boolean,
     private val currentUserId: Long
-) :
-    RecyclerView.Adapter<FollowAdapter.ViewHolder>() {
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FollowAdapter.ViewHolder {
-        val view = LayoutInflater.from(context).inflate(R.layout.item_follow_list, parent, false)
-        return ViewHolder(view)
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): RecyclerView.ViewHolder {
+        return if (viewType == ValueUtil.VIEW_TYPE_ITEM) {
+            val view =
+                LayoutInflater.from(context).inflate(R.layout.item_follow_list, parent, false)
+            ItemViewHolder(view)
+        } else {
+            val view = LayoutInflater.from(context).inflate(R.layout.item_loading, parent, false)
+            LoadingViewHolder(view)
+        }
+
     }
 
-    override fun onBindViewHolder(holder: FollowAdapter.ViewHolder, position: Int) {
-        holder.bind(data[position]) // view 바인딩
+    override fun getItemViewType(position: Int): Int {
+        return if (data[position] == null) ValueUtil.VIEW_TYPE_LOADING else ValueUtil.VIEW_TYPE_ITEM
+    }
 
-        // 닉네임 클릭 시
-        holder.textNickname.setOnClickListener {
-            UserProfile(context as Activity).moveToUserPage(data[position].userId)
-        }
-        // 프로필 이미지 클릭 시
-        holder.imageProfile.setOnClickListener {
-            UserProfile(context as Activity).moveToUserPage(data[position].userId)
-        }
-        // 리스트 상에서 본인이 들어가 있는 경우 버튼 hidden
-        holder.removeButton.visibility =
-            if (data[position].userId == ResponseExistLogin.baseUserInfo?.userId) View.GONE else View.VISIBLE
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        if (holder is ItemViewHolder) {
+            holder.bind(data[position]!!) // view 바인딩
 
-        val token =
-            ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(context).getAccessTokenFromLocal() // 요청 토큰
+            // 닉네임 클릭 시
+            holder.textNickname.setOnClickListener {
+                UserProfile(context as Activity).moveToUserPage(data[position]!!.userId)
+            }
+            // 프로필 이미지 클릭 시
+            holder.imageProfile.setOnClickListener {
+                UserProfile(context as Activity).moveToUserPage(data[position]!!.userId)
+            }
+            // 리스트 상에서 본인이 들어가 있는 경우 버튼 hidden
+            holder.removeButton.visibility =
+                if (data[position]!!.userId == ResponseExistLogin.baseUserInfo?.userId) View.GONE else View.VISIBLE
 
-        /*
+            val token =
+                ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(context).getAccessTokenFromLocal() // 요청 토큰
+
+            /*
         로그인 & 비로그인 유저 구분 / 내 팔로우(워) 리스트 & 다른 유저 팔로우(워) 리스트 구분 / 팔로우 & 팔로워 상태 구분
          */
-        if (ResponseExistLogin.baseUserInfo != null && JwtTokenUtil(context).getAccessTokenFromLocal() != "") { // 로그인한 유저라면
-            if (currentUserId == ResponseExistLogin.baseUserInfo?.userId) { // 내 팔로우(워) 리스트인 경우
-                if (state) { // 팔로우 리스트
-                    convertToFollowingState(holder.removeButton) // 팔로잉 버튼 상태로 전환
-                    // 우측 버튼 클릭 이벤트
-                    holder.removeButton.setOnClickListener {
-                        // 다이얼로그
-                        DialogUtil().MultipleDialog(
-                            context,
-                            "정말 '${data[position].nickname}'님의 팔로우를 취소하시겠습니까?",
-                            "예",
-                            "아니오",
-                            {
-                                CoroutineScope(Dispatchers.Main).launch {
-                                    val result =
-                                        Follow().startUnFollowRequest(
-                                            token,
-                                            data[position].userId
-                                        ) // 언팔로우 요청
-                                    if (result) { // 언팔로우 요청 성공 시
-                                        removeItem(position) // 아이템 제거
-                                    } else
-                                        dialogRequestFail()
-                                }
-                            }).show()
+            if (ResponseExistLogin.baseUserInfo != null && JwtTokenUtil(context).getAccessTokenFromLocal() != "") { // 로그인한 유저라면
+                if (currentUserId == ResponseExistLogin.baseUserInfo?.userId) { // 내 팔로우(워) 리스트인 경우
+                    if (state) { // 팔로우 리스트
+                        convertToFollowingState(holder.removeButton) // 팔로잉 버튼 상태로 전환
+                        // 우측 버튼 클릭 이벤트
+                        holder.removeButton.setOnClickListener {
+                            // 다이얼로그
+                            DialogUtil().MultipleDialog(
+                                context,
+                                "정말 '${data[position]!!.nickname}'님의 팔로우를 취소하시겠습니까?",
+                                "예",
+                                "아니오",
+                                {
+                                    CoroutineScope(Dispatchers.Main).launch {
+                                        val result =
+                                            Follow().startUnFollowRequest(
+                                                token,
+                                                data[position]!!.userId
+                                            ) // 언팔로우 요청
+                                        if (result) { // 언팔로우 요청 성공 시
+                                            removeAt(position) // 아이템 제거
+                                        } else
+                                            dialogRequestFail()
+                                    }
+                                }).show()
+                        }
+                    } else { // 팔로워 리스트
+                        if (data[position]!!.isFollowing) // 팔로우 중이라면
+                            convertToFollowingState(holder.removeButton) // 팔로잉 버튼 상태로 전환
+                        else // 팔로우 중이 아니라면
+                            convertToFollowState(holder.removeButton) // 팔로우 버튼 상태로 전환
+
+                        // 우측 버튼 클릭 이벤트
+                        holder.removeButton.setOnClickListener {
+                            clickFollowStateButton(position, token, holder)
+                        }
                     }
-                } else { // 팔로워 리스트
-                    if (data[position].isFollowing) // 팔로우 중이라면
+                } else { // 다른 사람 리스트인 경우
+                    if (data[position]!!.isFollowing) // 팔로우 중이라면
                         convertToFollowingState(holder.removeButton) // 팔로잉 버튼 상태로 전환
                     else // 팔로우 중이 아니라면
                         convertToFollowState(holder.removeButton) // 팔로우 버튼 상태로 전환
@@ -99,19 +126,9 @@ class FollowAdapter(
                         clickFollowStateButton(position, token, holder)
                     }
                 }
-            } else { // 다른 사람 리스트인 경우
-                if (data[position].isFollowing) // 팔로우 중이라면
-                    convertToFollowingState(holder.removeButton) // 팔로잉 버튼 상태로 전환
-                else // 팔로우 중이 아니라면
-                    convertToFollowState(holder.removeButton) // 팔로우 버튼 상태로 전환
-
-                // 우측 버튼 클릭 이벤트
-                holder.removeButton.setOnClickListener {
-                    clickFollowStateButton(position, token, holder)
-                }
+            } else {
+                holder.removeButton.visibility = View.GONE // 비로그인 유저의 경우 버튼 모두 숨김
             }
-        } else {
-            holder.removeButton.visibility = View.GONE // 비로그인 유저의 경우 버튼 모두 숨김
         }
     }
 
@@ -126,12 +143,12 @@ class FollowAdapter(
     private fun clickFollowStateButton(
         position: Int,
         token: String,
-        holder: ViewHolder
+        holder: ItemViewHolder
     ) {
-        if (data[position].isFollowing) { // 팔로우 중이라면
+        if (data[position]!!.isFollowing) { // 팔로우 중이라면
             DialogUtil().MultipleDialog(
                 context,
-                "정말 '${data[position].nickname}'님의 팔로우를 취소하시겠습니까?",
+                "정말 '${data[position]!!.nickname}'님의 팔로우를 취소하시겠습니까?",
                 "예",
                 "아니오",
                 {
@@ -139,11 +156,11 @@ class FollowAdapter(
                         val result =
                             Follow().startUnFollowRequest(
                                 token,
-                                data[position].userId
+                                data[position]!!.userId
                             ) // 언팔로우 요청
                         if (result) { // 언팔로우 요청 성공 시
                             convertToFollowState(holder.removeButton) // 버튼 상태 전환
-                            data[position].isFollowing = false // 팔로잉 상태로 전환
+                            data[position]!!.isFollowing = false // 팔로잉 상태로 전환
                         } else
                             dialogRequestFail() // 실패에 대한 다이얼로그
                     }
@@ -151,10 +168,10 @@ class FollowAdapter(
         } else { // 팔로우 중이 아니라면
             CoroutineScope(Dispatchers.Main).launch {
                 val result =
-                    Follow().startFollowRequest(token, data[position].userId) // 팔로우 요청
+                    Follow().startFollowRequest(token, data[position]!!.userId) // 팔로우 요청
                 if (result) { // 팔로우 요청 성공 시
                     convertToFollowingState(holder.removeButton) // 버튼 상태 전환
-                    data[position].isFollowing = true // 팔로우 상태로 전환
+                    data[position]!!.isFollowing = true // 팔로우 상태로 전환
                 } else
                     dialogRequestFail() // 실패에 대한 다이얼로그
             }
@@ -165,7 +182,7 @@ class FollowAdapter(
         return data.size
     }
 
-    inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+    inner class ItemViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val textNickname: TextView = itemView.findViewById(R.id.tv_following_nickname)
         private val textStatus: TextView = itemView.findViewById(R.id.tv_following_status)
         val imageProfile: ImageView = itemView.findViewById(R.id.imgv_following_profile)
@@ -182,17 +199,76 @@ class FollowAdapter(
         }
     }
 
+    inner class LoadingViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        private val progressDialog = itemView.findViewById<ProgressBar>(R.id.progressbar_loading)
+    }
+
     /**
      * 리스트에서 아이템을 동적으로 지우는 함수
      * @param position(Int): 지우고자 하는 인덱스
      * @author Seunggun Sin
      * @since 2022-07-31
      */
-    fun removeItem(position: Int) {
+    fun removeAt(position: Int) {
         if (position >= 0) {
             data.removeAt(position)
-            notifyDataSetChanged()
+            notifyItemRemoved(position)
         }
+    }
+
+    /**
+     * 리스트에서 아이템을 동적으로 지우는 함수
+     * @param item(FollowData): 지우고자 하는 객체
+     * @author Seunggun Sin
+     * @since 2022-08-18
+     */
+    fun removeItem(item: FollowData) {
+        data.remove(item)
+        notifyItemRemoved(data.indexOf(item))
+    }
+
+    /**
+     * 응답으로 받아온 리스트를 리스트에 추가하는 함수
+     * @param items(List<FollowData>): 팔로우 데이터 리스트
+     * @author Seunggun Sin
+     * @since 2022-08-18
+     */
+    fun addItems(items: List<FollowData>) {
+        data.addAll(items)
+        notifyItemRangeInserted(itemCount, items.size)
+    }
+
+    /**
+     * 응답으로 받아온 데이터를 리스트에 추가하는 함수
+     * @param item(FollowData): 팔로우 데이터
+     * @author Seunggun Sin
+     * @since 2022-08-18
+     */
+    fun addItem(item: FollowData?) {
+        data.add(item)
+        notifyItemInserted(itemCount)
+    }
+
+    /**
+     * 리스트의 마지막 아이템을 지우는 함수
+     * @author Seunggun Sin
+     * @since 2022-08-18
+     */
+    fun removeLast() {
+        data.removeAt(data.size - 1)
+        notifyItemRemoved(data.size)
+    }
+
+    /**
+     * 응답으로 받아온 데이터를 리스트에 추가하는 함수
+     * @param index(Int): 추가할 인덱스
+     * @param item(FollowData): 팔로우 데이터
+     * @author Seunggun Sin
+     * @since 2022-08-18
+     */
+    fun addItemIndex(index: Int, item: FollowData) {
+        data.add(index, item)
+        notifyItemInserted(index)
     }
 
     /**

--- a/Breaking/app/src/main/java/com/dope/breaking/follow/Follow.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/follow/Follow.kt
@@ -8,6 +8,7 @@ import com.dope.breaking.exception.UnLoginAccessException
 import com.dope.breaking.model.FollowData
 import com.dope.breaking.retrofit.RetrofitManager
 import com.dope.breaking.retrofit.RetrofitService
+import com.dope.breaking.util.ValueUtil
 
 /**
  * 팔로우 관련 처리를 하는 클래스
@@ -21,17 +22,23 @@ class Follow {
 
     /**
      * userId 에 해당하는 사람의 팔로우 목록을 가져오는 요청
+     * @param cursorId(Int): 마지막으로 가져온 리스트의 마지막 인덱스 값(리스트의 인덱스)
      * @param token(String): 요청하는 유저의 Jwt 토큰 (없으면 비회원 유저)
      * @param userId(Long): 요청 대상의 고유 id
      * @return List<FollowData>: userId 가 팔로우한 사람들에 대한 리스트
      * @throws ResponseErrorException: 응답 코드가 2xx 가 아닌 응답에 대한 예외 처리
      * @author Seunggun Sin
-     * @since 2022-07-28
+     * @since 2022-07-28 | 2022-08-18
      */
     @Throws(ResponseErrorException::class)
-    suspend fun startGetFollowingList(token: String, userId: Long): List<FollowData> {
+    suspend fun startGetFollowingList(
+        cursorId: Int,
+        token: String,
+        userId: Long
+    ): List<FollowData> {
         val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
-        val response = service.requestGetFollowingList(token, userId)
+        val response =
+            service.requestGetFollowingList(token, userId, cursorId, ValueUtil.FOLLOW_SIZE)
 
         if (response.isSuccessful) {
             val body = response.body()
@@ -46,17 +53,19 @@ class Follow {
 
     /**
      * userId 에 해당하는 사람의 팔로워 목록을 가져오는 요청
+     * @param cursorId(Int): 마지막으로 가져온 리스트의 마지막 인덱스 값(리스트의 인덱스)
      * @param token(String): 요청하는 유저의 Jwt 토큰 (없으면 비회원 유저)
      * @param userId(Long): 요청 대상의 고유 id
      * @return List<FollowData>: userId 를 팔로워한 사람들에 대한 리스트
      * @throws ResponseErrorException: 응답 코드가 2xx 가 아닌 응답에 대한 예외 처리
      * @author Seunggun Sin
-     * @since 2022-07-28
+     * @since 2022-07-28 | 2022-08-18
      */
     @Throws(ResponseErrorException::class)
-    suspend fun startGetFollowerList(token: String, userId: Long): List<FollowData> {
+    suspend fun startGetFollowerList(cursorId: Int, token: String, userId: Long): List<FollowData> {
         val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
-        val response = service.requestGetFollowerList(token, userId)
+        val response =
+            service.requestGetFollowerList(token, userId, cursorId, ValueUtil.FOLLOW_SIZE)
 
         if (response.isSuccessful) {
             val body = response.body()
@@ -86,7 +95,7 @@ class Follow {
         }
         val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
 
-        val response = service.requestFollow(token, userId)
+        val response = service.requestFollow(token, userId) // 팔로우 요청
 
         if (response.isSuccessful) {
             return response.code() in 200..299
@@ -112,7 +121,7 @@ class Follow {
         }
         val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
 
-        val response = service.requestUnFollow(token, userId)
+        val response = service.requestUnFollow(token, userId) // 언팔로우 요청
 
         if (response.isSuccessful) {
             return response.code() in 200..299

--- a/Breaking/app/src/main/java/com/dope/breaking/model/FollowData.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/FollowData.kt
@@ -1,9 +1,10 @@
 package com.dope.breaking.model
 
 data class FollowData(
-    val userId: Long,
-    val nickname: String,
-    val statusMsg: String,
-    val profileImgURL: String,
-    var isFollowing: Boolean
+    val cursorId: Int, // DB에 저장된 PK
+    val userId: Long, // 유저 고유 아이디
+    val nickname: String, // 닉네임
+    val statusMsg: String, // 상태 메세지
+    val profileImgURL: String, // 프로필 이미지 URL
+    var isFollowing: Boolean // 내가 userId 에 해당하는 사람을 팔로우하고 있는지
 )

--- a/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
@@ -208,26 +208,34 @@ interface RetrofitService {
      * userId 에 해당하는 사람의 팔로잉 리스트를 가져오는 요청
      * @header authorization: 요청하는 유저의 Jwt 토큰 값
      * @path userId: 팔로잉 리스트를 얻고자 하는 유저의 고유 아이디
+     * @query cursor: 마지막으로 요청한 마지막 id
+     * @query size: 팔로우 리스트에서 가져올 아이템 개수
      * @response userId 에 해당하는 사람이 팔로우한 사람들의 리스트
      * @author Seunggun Sin
      */
     @GET("follow/following/{userId}")
     suspend fun requestGetFollowingList(
         @Header("authorization") token: String,
-        @Path("userId") userId: Long
+        @Path("userId") userId: Long,
+        @Query("cursor") cursorId: Int,
+        @Query("size") contentSize: Int
     ): Response<List<FollowData>>
 
     /**
      * userId 에 해당하는 사람의 팔로워 리스트를 가져오는 요청
      * @header authorization: 요청하는 유저의 Jwt 토큰 값
      * @path userId: 팔로워 리스트를 얻고자 하는 유저의 고유 아이디
+     * @query cursor: 마지막으로 요청한 마지막 id
+     * @query size: 팔로우 리스트에서 가져올 아이템 개수
      * @response userId 에 해당하는 사람을 팔로워한 사람들의 리스트
      * @author Seunggun Sin
      */
     @GET("follow/follower/{userId}")
     suspend fun requestGetFollowerList(
         @Header("authorization") token: String,
-        @Path("userId") userId: Long
+        @Path("userId") userId: Long,
+        @Query("cursor") cursorId: Int,
+        @Query("size") contentSize: Int
     ): Response<List<FollowData>>
 
     /**

--- a/Breaking/app/src/main/java/com/dope/breaking/util/ValueUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/ValueUtil.kt
@@ -19,6 +19,9 @@ class ValueUtil {
         const val JWT_REQUEST_PREFIX = "Bearer " // Jwt 토큰을 헤더에 넣고 요청할 때 필요한 접두사
         const val FILTER_DATE_FORMAT_SUFFIX = "T00:00" // 피드 요청 시 "기간" 필터의 날짜 형식에 대한 접미사
         const val FEED_SIZE = 10 // 피드 요청마다 가져올 게시글 개수
+        const val FOLLOW_SIZE = 15 // 팔로우 리스트 요청 시 가져올 아이템 개수
+        const val VIEW_TYPE_ITEM = 0 // 일반 아이템에 대한 레이아웃 view type
+        const val VIEW_TYPE_LOADING = 1 // 로딩 아이템에 대한 레이아웃 view type
 
         val TAB_ICONS = arrayOf(
             R.drawable.ic_baseline_create_24,

--- a/Breaking/app/src/main/res/drawable/image_button_click_background.xml
+++ b/Breaking/app/src/main/res/drawable/image_button_click_background.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape>
+            <corners android:radius="80dp" />
+            <solid android:color="@color/gray" />
+
+        </shape>
+    </item>
+    <item android:state_pressed="false">
+        <shape>
+            <corners android:radius="80dp" />
+            <solid android:color="@color/white" />
+        </shape>
+    </item>
+</selector>

--- a/Breaking/app/src/main/res/layout/activity_follow.xml
+++ b/Breaking/app/src/main/res/layout/activity_follow.xml
@@ -6,6 +6,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     tools:context=".FollowActivity">
+
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/following_tool_bar"
         android:layout_width="match_parent"
@@ -14,18 +15,35 @@
         android:elevation="2dp"
         app:title="팔로잉 페이지"
         app:titleTextColor="@color/black" />
+
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rcv_following"
-            android:overScrollMode="never"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
+            android:overScrollMode="never"
             android:scrollbarAlwaysDrawVerticalTrack="true"
-            android:scrollbarSize="8dp"
+            android:scrollbarSize="13dp"
             android:scrollbars="vertical"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+        <ProgressBar
+            android:id="@+id/progressbar_loading"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_gravity="center"
+            android:indeterminateTint="@color/breaking_color"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/hashtag_bottom_divider" />
+
     </LinearLayout>
 
 </LinearLayout>

--- a/Breaking/app/src/main/res/layout/item_post_list.xml
+++ b/Breaking/app/src/main/res/layout/item_post_list.xml
@@ -9,7 +9,8 @@
         android:id="@+id/img_btn_post_more_menu"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:background="@drawable/ic_baseline_more_horiz_24"
+        android:src="@drawable/ic_baseline_more_horiz_24"
+        android:background="@drawable/image_button_click_background"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.45" />


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #74 

## 예상 리뷰 시간
20-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 기존 팔로우 & 팔로워 리스트 방식을 Pagination(cursor & size)로 구현(size = 15)
  - 팔로우 데이터 cursorId 필드 추가(Follow 테이블 PK)
  - 팔로우 리스트에 ProgressBar 추가
  - 메인 피드처럼 스크롤 이벤트로 갱신 요청
    - 로딩 아이템 추가
    - 리사이클러 뷰 어댑터 CRUD 함수 notify 함수 변경
- 메인 피드도 CRUD 함수 notify 함수 변경
- 메인 피드 더보기 메뉴 함수 클릭 drawable 추가
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
- 임의로 팔로우 리스트 pagination 테스트 위해 데이터 추가한 상태 
<img src="https://user-images.githubusercontent.com/54919474/185417476-c02b35f3-b589-4328-af7c-306646ebcfc3.png" width="30%" height="30%"/>

- 다음 요청으로 받은 리스트(로딩 아이템이 순식간에 지나가서 캐치 못함)
<img src="https://user-images.githubusercontent.com/54919474/185417502-f858c53b-a639-4290-aa5b-65a0efeca68f.png" width="30%" height="30%"/>

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 팔로우 리스트 페이지에 이미 모듈화가 되어있어서 거의 싹 다 갈아엎었어야했다. 그래서 pagination으로 구현하는데 조금 번거로웠다. 메인 피드처럼 요청만 하는 함수와 전처리, 후처리, 에러 동작을 구분하여 처리해주었다. 마찬가지로 초기 로딩과 갱신할 때 로딩아이템을 추가했다. 
- 팔로우 리스트에서 이전에 스크롤 바를 만들어뒀었는데, pagination으로 바꾸고 난 뒤, 스크롤 바가 사라지는 이상한 버그가 생겼다.... 원인은 여전히 모르겠다.
- 이제 팔로우 리스트를 스크롤해서 갱신할 때, 로딩 아이템이 뜨고 그 바로 위치부터 새로운 아이템이 쫙 스크롤할 때마다 나와야되는데, 이상하게 부자연스럽게 로딩아이템이 띄워질 때, 스크롤 위치가 리스트의 가장 위로 올라가는 현상이 있었다. 이거는 누가봐도 보기에 부자연스러웠기 때문에 무조건 해결해야겠다고 생각했다. 
  - 처음에 구글링 해보다가 리사이클러 뷰의 layout manager에 있는 `scrollToPosition()` 함수를 통해 스크롤의 위치를 조정할 수 있다고 했다. 하지만 데이터가 추가된 후 위 함수를 호출했지만 아무런 변화가 없었다. 
  - 그러다가 문득 생각난 것이 아이템을 추가하면서 리사이클러 뷰를 업데이트시키는 것이기 때문에 업데이트하는 과정에서 위 현상이 발생했다고 추측이 되었다. 그러다가 리사이클러 뷰의 어댑터에 정의해놓은 add, remove, clear 등 CRUD 메소드에서 `notifyDataSetChanged()` 함수를 호출해줬는데, 이 부분에 대해 유심히 찾아보았다. 찾아본 결과로 리스트의 크기와 아이템이 둘다 변경되는 경우에 리스트를 다시 그려주는 역할을 한다고 했다. 그래서 새롭게 들어온 아이템을이 들어와서 이 함수가 호출되면 다시 그려지는 것이기 때문에 최초의 상태로 돌아가게 되는 것이라고 생각이 되었다. 
  - 그래서 이를 해결하기 위해 전체 갱신이 아니라 딱 바뀐 부분만(아이템 추가한 것만, 지운 것만 등등) 갱신하도록 다른 `notifyXXX()` 함수를 이용했다. 그렇게 해주니 새로운 아이템을 가져올 때, 로딩 아이템이 잘 뜨고, 잘 사라지고, 새로운 아이템이 스크롤 순간이동 없이 순차적으로 스크롤을 내릴 때마다 잘 보여지게 되었다. 이 사실을 안 뒤에 메인 피드도 똑같이 업데이트 해주었다. 