### PR TITLE
fix: add handling for empty list in main feed

### DIFF
--- a/Breaking/app/src/main/java/com/dope/breaking/adapter/FeedAdapter.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/adapter/FeedAdapter.kt
@@ -65,11 +65,11 @@ class FeedAdapter(
     /**
      * 리스트에 비우는 함수
      * @author Seunggun Sin
-     * @since 2022-08-15 | 2022-08-18
+     * @since 2022-08-15 | 2022-08-25
      */
     fun clearList() {
         data.clear()
-        notifyItemRangeRemoved(0, itemCount)
+        notifyDataSetChanged()
     }
 
     /**
@@ -93,11 +93,17 @@ class FeedAdapter(
         notifyItemRemoved(data.size)
     }
 
-    fun replaceAll(items: List<ResponseMainFeed>){
+    /**
+     * 현재 아이템을 새로운 아이템으로 대체하는 함수
+     * @author Seunggun Sin
+     * @since 2022-08-18
+     */
+    fun replaceAll(items: List<ResponseMainFeed>) {
         data.clear()
         data.addAll(items)
         notifyDataSetChanged()
     }
+
     /**
      * 아이템 view type 을 가져옴
      */

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviHomeFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviHomeFragment.kt
@@ -79,11 +79,6 @@ class NaviHomeFragment : Fragment() {
                     // 리스트 보여주기
                     binding.tvNoFeedAlert.visibility = View.GONE
                     binding.rcvMainFeed.visibility = View.VISIBLE
-                    // 가져온 피드 리스트 할당 및 초기화
-                    feedList.clear()
-                    feedList = (it as List<ResponseMainFeed>).toMutableList()
-                    // 아이템 리스트 클릭시 상세 페이지로 이동
-                    moveToPostDetailPage()
                 }
                 adapter.addItems(it) // 받아온 리스트 추가하기
             }, {
@@ -119,11 +114,6 @@ class NaviHomeFragment : Fragment() {
                     // 리스트 보여주기
                     binding.tvNoFeedAlert.visibility = View.GONE
                     binding.rcvMainFeed.visibility = View.VISIBLE
-                    // 가져온 피드 리스트 할당 및 초기화
-                    feedList.clear()
-                    feedList = (it as List<ResponseMainFeed>).toMutableList()
-                    // 아이템 리스트 클릭시 상세 페이지로 이동
-                    moveToPostDetailPage()
                 }
                 adapter.addItems(it) // 받아온 리스트 추가하기
             }, {
@@ -154,9 +144,22 @@ class NaviHomeFragment : Fragment() {
         }, { it ->
             feedList.addAll(it) // 동적 리스트에 가져온 리스트 추가
             adapter = FeedAdapter(requireContext(), feedList) // 어댑터 초기화
-
-            // 아이템 리스트 클릭시 상세 페이지로 이동
-            moveToPostDetailPage()
+            adapter.setItemListClickListener(object : FeedAdapter.OnItemClickListener {
+                override fun onClick(v: View, position: Int) {
+                    moveToPostDetailPage(position)
+                }
+            })
+            if (it.isEmpty()) { // 리스트가 비어있다면
+                // 비어있다면 화면 뿌려주기
+                binding.tvNoFeedAlert.visibility = View.VISIBLE
+                binding.rcvMainFeed.visibility = View.GONE
+            } else { // 아니라면
+                // 리스트 보여주기
+                binding.tvNoFeedAlert.visibility = View.GONE
+                binding.rcvMainFeed.visibility = View.VISIBLE
+            }
+            // 로딩 종료
+            binding.progressbarLoading.visibility = View.GONE
 
             // 리스트의 divider 선 추가
             binding.rcvMainFeed.addItemDecoration(
@@ -165,9 +168,6 @@ class NaviHomeFragment : Fragment() {
                     LinearLayout.VERTICAL
                 )
             )
-            // 로딩 종료
-            binding.rcvMainFeed.visibility = View.VISIBLE
-            binding.progressbarLoading.visibility = View.GONE
 
             // 어댑터 지정
             binding.rcvMainFeed.adapter = adapter
@@ -182,6 +182,12 @@ class NaviHomeFragment : Fragment() {
                     // 스크롤하면서 리스트의 가장 마지막 위치에 도달했을 때, 그 인덱스 값 가져오기
                     val lastIndex =
                         (recyclerView.layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition()
+
+                    // 가져온 아이템 사이즈가 가져와야하는 사이즈보다 작은 경우 새로운 요청을 못하게 막기
+                    if (recyclerView.adapter!!.itemCount < ValueUtil.FEED_SIZE) {
+                        return
+                    }
+
                     // 실제 데이터 리스트의 마지막 인덱스와 스크롤 이벤트에 의한 인덱스 값이 같으면서
                     // 스크롤이 드래깅 중이면서
                     // 피드 요청이 더 가능하면서
@@ -251,17 +257,6 @@ class NaviHomeFragment : Fragment() {
                             false
                         ) == true // 제보글을 썼다면 true, 쓰지 않았다면 false
                     if (isWritePost) { // true 면 피드 다시 조회하여 refresh
-                        // 요청 Jwt 토큰 가져오기
-                        val token =
-                            ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(requireContext()).getAccessTokenFromLocal()
-
-                        // 피드 요청 에러 시 띄워줄 다이얼로그 정의
-                        val requestErrorDialog =
-                            DialogUtil().SingleDialog(
-                                requireContext(),
-                                "피드를 가져오는데 문제가 발생하였습니다.",
-                                "확인"
-                            )
 
                         processGetMainFeed(0, token, {
                             // 로딩 시작
@@ -269,26 +264,21 @@ class NaviHomeFragment : Fragment() {
                             binding.rcvMainFeed.visibility = View.GONE
                             adapter.clearList()
                             isObtainedAll = false
-                        }, { it ->
+                        }, {
                             feedList.addAll(it) // 동적 리스트에 가져온 리스트 추가
                             adapter = FeedAdapter(requireContext(), feedList) // 어댑터 초기화
 
-                            // 아이템 리스트 클릭시 상세 페이지로 이동
-                            moveToPostDetailPage()
-
-                            // 리스트의 divider 선 추가
-                            binding.rcvMainFeed.addItemDecoration(
-                                DividerItemDecoration(
-                                    requireActivity(),
-                                    LinearLayout.VERTICAL
-                                )
-                            )
+                            if (it.isEmpty()) { // 리스트가 비어있다면
+                                // 비어있다면 화면 뿌려주기
+                                binding.tvNoFeedAlert.visibility = View.VISIBLE
+                                binding.rcvMainFeed.visibility = View.GONE
+                            } else { // 아니라면
+                                // 리스트 보여주기
+                                binding.tvNoFeedAlert.visibility = View.GONE
+                                binding.rcvMainFeed.visibility = View.VISIBLE
+                            }
                             // 로딩 종료
-                            binding.rcvMainFeed.visibility = View.VISIBLE
                             binding.progressbarLoading.visibility = View.GONE
-
-                            // 어댑터 지정
-                            binding.rcvMainFeed.adapter = adapter
 
                             // 다시 false 로 변경
                             isWritePost = false
@@ -343,19 +333,14 @@ class NaviHomeFragment : Fragment() {
 
     /**
      * 어댑터에서 아이템 리스트를 클릭했을 때, 해당 postId를 받아와 세부 조회 액티비티로 넘겨주는 함수
-     * @param - None
-     * @return - None
-     * @author - Tae hyun Park
-     * @since - 2022-08-18
+     * @param position(Int): 현재 리스트의 인덱스
+     * @author Tae hyun Park | Seunggun Sin
+     * @since 2022-08-18 | 2022-08-25
      */
-    private fun moveToPostDetailPage() {
-        adapter.setItemListClickListener(object : FeedAdapter.OnItemClickListener {
-            override fun onClick(v: View, position: Int) {
-                Log.d(TAG, "클릭한 게시물 id : ${feedList[position]!!.postId}")
-                var intent = Intent(context, PostDetailActivity::class.java)
-                intent.putExtra("postId", feedList[position]!!.postId)
-                startActivity(intent)
-            }
-        })
+    private fun moveToPostDetailPage(position: Int) {
+        Log.d(TAG, "클릭한 게시물 id : ${feedList[position]!!.postId}")
+        val intent = Intent(context, PostDetailActivity::class.java)
+        intent.putExtra("postId", feedList[position]!!.postId)
+        startActivity(intent)
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/BookmarkedTabFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/BookmarkedTabFragment.kt
@@ -121,6 +121,7 @@ class BookmarkedTabFragment : Fragment() {
         binding.tvOptionAll.setOnClickListener {
             if (!isLoading) { // 로딩 중이 아닐 때 가능
                 optionState = 0 // 상태 변경
+                isObtainAll = false
                 processGetUserFeed(userId, 0, ValueUtil.FILTER_SELL_OPTIONS[optionState], token, {
                     isLoading = true // 로딩 상태 전환
                     selectOption(binding.tvOptionAll) // 옵션 선택 view 전환
@@ -145,6 +146,7 @@ class BookmarkedTabFragment : Fragment() {
         binding.tvOptionSold.setOnClickListener {
             if (!isLoading) {
                 optionState = 1
+                isObtainAll = false
                 processGetUserFeed(userId, 0, ValueUtil.FILTER_SELL_OPTIONS[optionState], token, {
                     isLoading = true
                     selectOption(binding.tvOptionSold)
@@ -167,6 +169,7 @@ class BookmarkedTabFragment : Fragment() {
         binding.tvOptionUnsold.setOnClickListener {
             if (!isLoading) {
                 optionState = 2
+                isObtainAll = false
                 processGetUserFeed(userId, 0, ValueUtil.FILTER_SELL_OPTIONS[optionState], token, {
                     isLoading = true
                     selectOption(binding.tvOptionUnsold)

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/PostTabFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/PostTabFragment.kt
@@ -121,6 +121,7 @@ class PostTabFragment : Fragment() {
         binding.tvOptionAll.setOnClickListener {
             if (!isLoading) { // 로딩 중이 아닐 때 가능
                 optionState = 0 // 상태 변경
+                isObtainAll = false
                 processGetUserFeed(userId, 0, ValueUtil.FILTER_SELL_OPTIONS[optionState], token, {
                     isLoading = true // 로딩 상태 전환
                     selectOption(binding.tvOptionAll) // 옵션 선택 view 전환
@@ -145,6 +146,7 @@ class PostTabFragment : Fragment() {
         binding.tvOptionSold.setOnClickListener {
             if (!isLoading) {
                 optionState = 1
+                isObtainAll = false
                 processGetUserFeed(userId, 0, ValueUtil.FILTER_SELL_OPTIONS[optionState], token, {
                     isLoading = true
                     selectOption(binding.tvOptionSold)
@@ -167,6 +169,7 @@ class PostTabFragment : Fragment() {
         binding.tvOptionUnsold.setOnClickListener {
             if (!isLoading) {
                 optionState = 2
+                isObtainAll = false
                 processGetUserFeed(userId, 0, ValueUtil.FILTER_SELL_OPTIONS[optionState], token, {
                     isLoading = true
                     selectOption(binding.tvOptionUnsold)

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/PurchasedTabFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/PurchasedTabFragment.kt
@@ -121,6 +121,7 @@ class PurchasedTabFragment : Fragment() {
         binding.tvOptionAll.setOnClickListener {
             if (!isLoading) { // 로딩 중이 아닐 때 가능
                 optionState = 0 // 상태 변경
+                isObtainAll = false
                 processGetUserFeed(userId, 0, ValueUtil.FILTER_SELL_OPTIONS[optionState], token, {
                     isLoading = true // 로딩 상태 전환
                     selectOption(binding.tvOptionAll) // 옵션 선택 view 전환
@@ -145,6 +146,7 @@ class PurchasedTabFragment : Fragment() {
         binding.tvOptionSold.setOnClickListener {
             if (!isLoading) {
                 optionState = 1
+                isObtainAll = false
                 processGetUserFeed(userId, 0, ValueUtil.FILTER_SELL_OPTIONS[optionState], token, {
                     isLoading = true
                     selectOption(binding.tvOptionSold)
@@ -167,6 +169,7 @@ class PurchasedTabFragment : Fragment() {
         binding.tvOptionUnsold.setOnClickListener {
             if (!isLoading) {
                 optionState = 2
+                isObtainAll = false
                 processGetUserFeed(userId, 0, ValueUtil.FILTER_SELL_OPTIONS[optionState], token, {
                     isLoading = true
                     selectOption(binding.tvOptionUnsold)


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #87 

## 예상 리뷰 시간
3-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 유저 페이지에서 옵션으로 새롭게 요청 후, 다른 옵션을 설정하여 다시 요청했을 때 스크롤 이벤트로 새로운 게시글을 요청하는 동작이 이루어지지 않는 문제 해결
  - 스크롤 이벤트의 조건문인 `isObtainedAll` 필드를 매 옵션마다 초기화 시켜주었다. 
- 메인 피드에서 초기 요청 시, 아이템이 없을 때, 비어있다는 문구 처리가 없고 스크롤 이벤트가 작동되어 발생한 문제 해결
- 메인 피드에서 옵션 등을 사용하여 새로 요청했을 때 아이템 개수가 기존 요청할 때 가져오는 최대 개수보다 작을 때에는 스크롤 이벤트로 새로운 게시글 요청을 못하도록 조건 추가
- 피드 어댑터의 `clear` 함수의 notify 함수 변경
- 메인 피드 코드 일부분 리팩토링
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
x
## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 불필요한 코드를 제거 했습니다. 더 꼼꼼하게 코드 리뷰를 해야할 필요성을 느끼네요.
  - 어댑터로 아이템 클릭 시, 세부 조회로 가는 `moveToPostDetailPage()` 함수에 걸맞게 호출이 되면 화면만 이동하도록 해야하는데, 어댑터의 아이템 클릭 이벤트 정의까지 모두 담겨있네요. 
  - 리스너는 한번만 지정해주면 계속 유지가 되기 때문에 최초 요청 시, 한번만 지정해주면 리스트의 변화에 따라 어댑터가 자동으로 따라가기 때문에, 모든 요청마다 새로운 클릭 이벤트 지정하는 함수를 지정해줄 필요가 없을 것 같습니다. 