### PR TITLE
fix: modify logic error difference of date in feed

### DIFF
--- a/Breaking/app/src/main/java/com/dope/breaking/util/DateUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/DateUtil.kt
@@ -10,19 +10,14 @@ class DateUtil {
      * @param date(String): 문자열 형태의 날짜 데이터 (포맷: "yyyy-MM-ddTHH:mm:ss.fp" or "yyyy-MM-dd HH:mm:ss"")
      * @return String: 현재와 날짜 차이를 적절한 범위에 해당하는 초/분/시/일 단위로 반환
      * @author Seunggun Sin
-     * @since 2022-08-10
+     * @since 2022-08-10 | 2022-08-28
      */
     fun getTimeDiff(date: String): String {
-        if (!(date.length == 26 || date.length == 19)) { // 형식에 맞지 않으면 에러 리턴
-            return "-"
-        }
         val today = Calendar.getInstance() // 오늘 날짜 가져오기
         var newDate: String = date // 가져온 날짜를 가공할 변수
 
-        if (date.length == 26) { // 서버 기준 포맷이라면
-            newDate = date.replace("T", " ")
-            newDate = newDate.split(".")[0]
-        }
+        newDate = date.replace("T", " ")
+        newDate = newDate.split(".")[0]
 
         try {
             val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss") // 형식 맞추기


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #93

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 피드에서 작성된 날짜와 현재날짜의 차이를 적절한 단위로 보여주는 기능에서 알고리즘의 문제로 에러 표시인 `-`가 나오는 버그가 있었는데, 이 로직에서 불필요한 조건을 제거함으로써 해결했다.
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
x
## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
x