### PR TITLE
refactor: modify to send null when no image in sign-up request

### DIFF
--- a/Breaking/app/src/main/java/com/dope/breaking/EditProfileActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/EditProfileActivity.kt
@@ -16,6 +16,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.dope.breaking.databinding.ActivitySignUpBinding
 import com.dope.breaking.model.request.RequestUpdateUser
 import com.dope.breaking.model.response.DetailUser
@@ -167,7 +168,7 @@ class EditProfileActivity : AppCompatActivity() {
      * 초기 View 에 데이터 채워넣기
      * @param data(DetailUser): 기존 유저 데이터
      * @author Seunggun Sin
-     * @since 2022-07-25
+     * @since 2022-07-25 | 2022-08-29
      */
     private fun fillDataInView(data: DetailUser) {
         binding.etName.setText(data.realName)
@@ -175,10 +176,18 @@ class EditProfileActivity : AppCompatActivity() {
         binding.etNickname.setText(data.nickname)
         binding.etPhoneNumber.setText(data.phoneNumber)
         binding.etStateMessage.setText(data.statusMsg)
-        Glide.with(this)
-            .load(ValueUtil.IMAGE_BASE_URL + data.profileImgURL)
-            .circleCrop()
-            .into(binding.imgBtnProfileImage)
+        if (data.profileImgURL != null) {
+            Glide.with(this)
+                .load(ValueUtil.IMAGE_BASE_URL + data.profileImgURL)
+                .placeholder(R.drawable.ic_default_profile_image)
+                .circleCrop()
+                .into(binding.imgBtnProfileImage)
+        } else {
+            Glide.with(this)
+                .load(R.drawable.ic_default_profile_image)
+                .circleCrop()
+                .into(binding.imgBtnProfileImage)
+        }
     }
 
     /**

--- a/Breaking/app/src/main/java/com/dope/breaking/SignUpActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/SignUpActivity.kt
@@ -152,7 +152,7 @@ class SignUpActivity : AppCompatActivity() {
      */
     private suspend fun processSignUp(
         inputData: RequestSignUp,
-        imageData: Bitmap,
+        imageData: Bitmap?,
         imageName: String
     ) {
         try {
@@ -283,8 +283,7 @@ class SignUpActivity : AppCompatActivity() {
                     // 회원가입 요청 시작, 회원가입 버튼 클릭하고 검증 완료 후 input 데이터와 함께 호출
                     processSignUp(
                         inputData = inputData,
-                        imageData = profileImgBitmap
-                            ?: ValueUtil.getDefaultProfile(this@SignUpActivity),
+                        imageData = profileImgBitmap,
                         imageName = filename ?: "default.png"
                     )
                     Log.d(TAG, "filename test : " + filename)

--- a/Breaking/app/src/main/java/com/dope/breaking/UserPageActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/UserPageActivity.kt
@@ -176,7 +176,7 @@ class UserPageActivity : AppCompatActivity() {
      * 응답으로 받아온 대상 유저의 데이터를 바탕으로 유저 프로필 view 에 뿌려주기
      * @param user(User): 대상 유저 데이터 객체
      * @author Seunggun Sin
-     * @since 2022-07-29 | 2022-07-31
+     * @since 2022-07-29 | 2022-08-29
      */
     private fun fillDataInView(user: User) {
         findViewById<TextView>(R.id.tv_my_page_nickname).text = user.nickname
@@ -186,14 +186,21 @@ class UserPageActivity : AppCompatActivity() {
         findViewById<TextView>(R.id.tv_post_value).text = user.postCount.toString()
 
         if (init)
-            Glide.with(this@UserPageActivity) // 이미지 보여주기
-                .load(ValueUtil.IMAGE_BASE_URL + user.profileImgURL) // url 에 대한 이미지 호출
-                .placeholder(R.drawable.ic_default_profile_image)
-                .fitCenter()
-                .circleCrop() // 이미지 원형으로 만들기
-                .diskCacheStrategy(DiskCacheStrategy.ALL) // 이미지 캐싱
-                .error(R.drawable.ic_default_profile_image) // url 호출 에러 시 기본 이미지
-                .into(findViewById(R.id.img_view_my_page_profile))
+            if (user.profileImgURL != null)
+                Glide.with(this@UserPageActivity) // 이미지 보여주기
+                    .load(ValueUtil.IMAGE_BASE_URL + user.profileImgURL) // url 에 대한 이미지 호출
+                    .placeholder(R.drawable.ic_default_profile_image)
+                    .fitCenter()
+                    .circleCrop() // 이미지 원형으로 만들기
+                    .error(R.drawable.ic_default_profile_image) // url 호출 에러 시 기본 이미지
+                    .into(findViewById(R.id.img_view_my_page_profile))
+            else
+                Glide.with(this@UserPageActivity)
+                    .load(R.drawable.ic_default_profile_image)
+                    .fitCenter()
+                    .circleCrop()
+                    .into(findViewById(R.id.img_view_my_page_profile))
+
     }
 
     /**

--- a/Breaking/app/src/main/java/com/dope/breaking/adapter/FollowAdapter.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/adapter/FollowAdapter.kt
@@ -191,11 +191,18 @@ class FollowAdapter(
         fun bind(item: FollowData) {
             textNickname.text = item.nickname
             textStatus.text = item.statusMsg
-            Glide.with(itemView)
-                .load(ValueUtil.IMAGE_BASE_URL + item.profileImgURL)
-                .circleCrop()
-                .error(R.drawable.ic_default_profile_image)
-                .into(imageProfile)
+            if (item.profileImgURL != null)
+                Glide.with(itemView)
+                    .load(ValueUtil.IMAGE_BASE_URL + item.profileImgURL)
+                    .placeholder(R.drawable.ic_default_profile_image)
+                    .circleCrop()
+                    .error(R.drawable.ic_default_profile_image)
+                    .into(imageProfile)
+            else
+                Glide.with(itemView)
+                    .load(R.drawable.ic_default_profile_image)
+                    .circleCrop()
+                    .into(imageProfile)
         }
     }
 

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviUserFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviUserFragment.kt
@@ -92,14 +92,19 @@ class NaviUserFragment : Fragment() {
         /*
             받아온 유저 데이터를 view 에 뿌려주기
          */
-        Glide.with(this) // 이미지 보여주기
-            .load(ValueUtil.IMAGE_BASE_URL + userData.profileImgURL) // url 에 대한 이미지 호출
-            .placeholder(R.drawable.ic_default_profile_image)
-            .fitCenter()
-            .circleCrop() // 이미지 원형으로 만들기
-            .diskCacheStrategy(DiskCacheStrategy.ALL) // 이미지 캐싱
-            .error(R.drawable.ic_default_profile_image) // url 호출 에러 시 기본 이미지
-            .into(binding.imgViewMyPageProfile)
+        if (userData.profileImgURL != null)
+            Glide.with(this) // 이미지 보여주기
+                .load(ValueUtil.IMAGE_BASE_URL + userData.profileImgURL) // url 에 대한 이미지 호출
+                .placeholder(R.drawable.ic_default_profile_image)
+                .fitCenter()
+                .circleCrop() // 이미지 원형으로 만들기
+                .error(R.drawable.ic_default_profile_image) // url 호출 에러 시 기본 이미지
+                .into(binding.imgViewMyPageProfile)
+        else
+            Glide.with(this)
+                .load(R.drawable.ic_default_profile_image)
+                .circleCrop()
+                .into(binding.imgViewMyPageProfile)
 
         binding.tvMyPageNickname.text = userData.nickname
         binding.tvMyPageStatus.text = userData.statusMsg

--- a/Breaking/app/src/main/java/com/dope/breaking/model/FollowData.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/FollowData.kt
@@ -5,6 +5,6 @@ data class FollowData(
     val userId: Long, // 유저 고유 아이디
     val nickname: String, // 닉네임
     val statusMsg: String, // 상태 메세지
-    val profileImgURL: String, // 프로필 이미지 URL
+    val profileImgURL: String?, // 프로필 이미지 URL
     var isFollowing: Boolean // 내가 userId 에 해당하는 사람을 팔로우하고 있는지
 )

--- a/Breaking/app/src/main/java/com/dope/breaking/model/response/DetailUser.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/response/DetailUser.kt
@@ -10,5 +10,5 @@ data class DetailUser(
     @SerializedName("realName") val realName: String,
     @SerializedName("role") val role: String,
     @SerializedName("statusMsg") val statusMsg: String,
-    @SerializedName("profileImgURL") val profileImgURL: String,
+    @SerializedName("profileImgURL") val profileImgURL: String?,
 ): Serializable

--- a/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseExistLogin.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseExistLogin.kt
@@ -6,7 +6,7 @@ import java.io.Serializable
 
 data class ResponseExistLogin(
     @SerializedName("userId") val userId: Long,
-    @SerializedName("profileImgURL") val profileImgUrl: String,
+    @SerializedName("profileImgURL") val profileImgUrl: String?,
     @SerializedName("nickname") val nickname: String,
     @SerializedName("balance") val balance: Int
 ) : Serializable {
@@ -15,7 +15,7 @@ data class ResponseExistLogin(
         fun convertJsonToObject(jsonObject: JSONObject): ResponseExistLogin {
             return ResponseExistLogin(
                 (jsonObject["userId"] as Int).toLong(),
-                jsonObject["profileImgURL"] as String,
+                jsonObject["profileImgURL"] as String?,
                 jsonObject["nickname"] as String,
                 jsonObject["balance"] as Int
             )

--- a/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseJwtUserInfo.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseJwtUserInfo.kt
@@ -5,6 +5,6 @@ import java.io.Serializable
 
 data class ResponseJwtUserInfo(
     @SerializedName("userId") val userId: Int, // 유저 고유 번호
-    @SerializedName("profileImgURL") val profileImgUrl: String, // 프로필 이미지 url
+    @SerializedName("profileImgURL") val profileImgUrl: String?, // 프로필 이미지 url
     @SerializedName("nickname") val nickname: String // 유저 닉네임
 ) : Serializable

--- a/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseLogin.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseLogin.kt
@@ -8,7 +8,7 @@ data class ResponseLogin(
     @SerializedName("fullname") var fullName: String, // 유저 성 이름
     @SerializedName("username") var userName: String, // 회원번호
     @SerializedName("email") var userEmail: String,   // 유저 이메일
-    @SerializedName("profileImgURL") var profileImgUrl: String // 프로필 이미지 Url
+    @SerializedName("profileImgURL") var profileImgUrl: String? // 프로필 이미지 Url
 ) : Serializable {
     companion object {
         fun convertJsonToObject(jsonObject: JSONObject): ResponseLogin {
@@ -16,7 +16,7 @@ data class ResponseLogin(
                 jsonObject["fullname"] as String,
                 jsonObject["username"] as String,
                 jsonObject["email"] as String,
-                jsonObject["profileImgURL"] as String
+                jsonObject["profileImgURL"] as String?
             )
         }
     }

--- a/Breaking/app/src/main/java/com/dope/breaking/model/response/User.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/response/User.kt
@@ -6,7 +6,7 @@ import java.io.Serializable
 
 data class User(
     @SerializedName("userId") val userId: Long,
-    @SerializedName("profileImgURL") val profileImgURL: String,
+    @SerializedName("profileImgURL") val profileImgURL: String?,
     @SerializedName("nickname") val nickname: String,
     @SerializedName("email") val email: String,
     @SerializedName("role") val role: String,
@@ -28,7 +28,7 @@ data class User(
             println(jsonObject.toString())
             return User(
                 (jsonObject["userId"] as Int).toLong(),
-                if (jsonObject.isNull("profileImgURL")) "" else jsonObject["profileImgURL"] as String,
+                jsonObject["profileImgURL"] as String?,
                 jsonObject["nickname"] as String,
                 jsonObject["email"] as String,
                 jsonObject["role"] as String,

--- a/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
@@ -117,7 +117,7 @@ interface RetrofitService {
     /**
      * 최종 회원가입 요청 메소드 - Multipart 요청
      * @param userAgent: 안드로이드 플랫폼 user-agent 헤더 값
-     * @param image(MultipartBody.Part): 이미지가 담긴 multi form 요청 body (key=profileImg)
+     * @param image(MultipartBody.Part?): 이미지가 담긴 multi form 요청 body (key=profileImg)
      * @param data(RequestBody): 나머지 텍스트 필드  값이 담긴 요청 body (key=signUpRequest)
      * @response Unit: 응답 body 자체는 중요 x, Jwt 토큰을 위한 헤더 값만 필요
      * @author Seunggun Sin
@@ -126,7 +126,7 @@ interface RetrofitService {
     @POST("oauth2/sign-up")
     suspend fun requestSignUp(
         @Header("User-Agent") userAgent: String,
-        @Part image: MultipartBody.Part,
+        @Part image: MultipartBody.Part?,
         @Part("signUpRequest") data: RequestBody
     ): Response<Unit>
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #94 

## 예상 리뷰 시간
3-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- `profileImgURL`이 들어간 모든 응답 DTO 클래스에서 `profileImgURL` 필드를 `nullable`로 변경
- 위에 nullable로 변경함에 따라 Glide에서 프로필 이미지를 로드할 때 발생하는 에러를 방지하기 위해 조건문으로 defensive 처리를 통해 기본 이미지를 보여주는식으로 분리시킴
- 회원가입 요청 시, 이미지를 선택하지 않았을 때 인위적으로 기본 프로필 이미지 drawable을 bitmap으로 변환하여 요청한 것을 기본 프로필 이미지를 보내지 않고 null로 보내는 것으로 수정
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
x
## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 회원가입 테스트는 하지 않아 문제 발생 시 수정하겠습니다. 