### PR TITLE
hotfix: add condition for checking null

### DIFF
--- a/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseExistLogin.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseExistLogin.kt
@@ -15,7 +15,7 @@ data class ResponseExistLogin(
         fun convertJsonToObject(jsonObject: JSONObject): ResponseExistLogin {
             return ResponseExistLogin(
                 (jsonObject["userId"] as Int).toLong(),
-                jsonObject["profileImgURL"] as String?,
+                if (jsonObject.isNull("profileImgURL")) null else jsonObject["profileImgURL"] as String?,
                 jsonObject["nickname"] as String,
                 jsonObject["balance"] as Int
             )

--- a/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseLogin.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseLogin.kt
@@ -16,7 +16,7 @@ data class ResponseLogin(
                 jsonObject["fullname"] as String,
                 jsonObject["username"] as String,
                 jsonObject["email"] as String,
-                jsonObject["profileImgURL"] as String?
+                if (jsonObject.isNull("profileImgURL")) null else jsonObject["profileImgURL"] as String?
             )
         }
     }

--- a/Breaking/app/src/main/java/com/dope/breaking/model/response/User.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/response/User.kt
@@ -28,7 +28,7 @@ data class User(
             println(jsonObject.toString())
             return User(
                 (jsonObject["userId"] as Int).toLong(),
-                jsonObject["profileImgURL"] as String?,
+                if (jsonObject.isNull("profileImgURL")) null else jsonObject["profileImgURL"] as String?,
                 jsonObject["nickname"] as String,
                 jsonObject["email"] as String,
                 jsonObject["role"] as String,


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #97 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- `profileImgURL` 필드를 nullable로 변경함에 따라 응답을 json으로 받을 시에 변환해주는 커스텀 메소드인 `convertJsonToObject()` 메소드에서 `profileImgURL` 필드 값이 null로 들어올 시, `String?` 타입에 매핑되지 않아 발생한 에러를 해결
  - `JSONObject` 타입의 `isNull()` 메소드를 통해 null 체크를 한 뒤, null이면 단순하게 null 값 할당, null이 아니라면 `as` 연산자를 사용하여 `String?` 타입으로 타입 변환 후 할당
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
x
## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
x