### PR TITLE
feat: implement string, hashtag, user search function

### DIFF
--- a/Breaking/app/src/main/AndroidManifest.xml
+++ b/Breaking/app/src/main/AndroidManifest.xml
@@ -3,14 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.dope.breaking">
 
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
-
     <application
         android:name=".GlobalApplication"
         android:allowBackup="false"
@@ -24,12 +16,16 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
+            android:name=".FeedSearchActivity"
+            android:windowSoftInputMode="adjustPan"
+            android:exported="false" />
+        <activity
             android:name=".board.PostDetailActivity"
             android:exported="false" />
         <activity
             android:name=".map.KakaoMapActivity"
             android:exported="false"
-            android:screenOrientation="portrait"></activity>
+            android:screenOrientation="portrait" />
         <activity
             android:name=".UserPageActivity"
             android:exported="false" />
@@ -95,6 +91,10 @@
             android:name=".SignUpActivity"
             android:exported="false" />
 
+        <meta-data
+            android:name="com.kakao.sdk.AppKey"
+            android:value="2d91a1b7acbe212ba78a24b4f006615a" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"
@@ -104,10 +104,14 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths" />
         </provider>
-
-        <meta-data
-            android:name="com.kakao.sdk.AppKey"
-            android:value="2d91a1b7acbe212ba78a24b4f006615a" />
     </application>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
 </manifest>

--- a/Breaking/app/src/main/java/com/dope/breaking/FeedSearchActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/FeedSearchActivity.kt
@@ -154,7 +154,7 @@ class FeedSearchActivity : AppCompatActivity() {
                     (recyclerView.layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition()
 
                 // 가져온 아이템 개수가 가져와야할 아이템 개수보다 적을 경우 스크롤 이벤트 무시
-                if (recyclerView.adapter!!.itemCount < 4) {
+                if (recyclerView.adapter!!.itemCount < ValueUtil.FEED_SIZE) {
                     return
                 }
 
@@ -172,7 +172,7 @@ class FeedSearchActivity : AppCompatActivity() {
                     searchFeed(currentCursor, token, {
                         if (searchState != 2) { // 게시글 검색이라면
                             val list = it as List<ResponseMainFeed> // 데이터 타입 변환
-                            if (list.size < 4) { // 정량으로 가져오는 개수보다 적다면
+                            if (list.size < ValueUtil.FEED_SIZE) { // 정량으로 가져오는 개수보다 적다면
                                 feedAdapter.removeLast() // 로딩 아이템 제거
                                 isObtainedAll = true // 더 이상 받아올 피드가 없다는 상태로 전환
                             } else { // 리스트가 있다면
@@ -180,7 +180,7 @@ class FeedSearchActivity : AppCompatActivity() {
                             }
                         } else { // 유저 검색이라면
                             val list = it as List<ResponseUserSearch> // 데이터 타입 변환
-                            if (list.size < 4) { // 정량으로 가져오는 개수보다 적다면
+                            if (list.size < ValueUtil.FEED_SIZE) { // 정량으로 가져오는 개수보다 적다면
                                 userAdapter.removeLast() // 로딩 아이템 제거
                                 isObtainedAll = true // 더 이상 받아올 피드가 없다는 상태로 전환
                             } else { // 리스트가 있다면
@@ -230,7 +230,7 @@ class FeedSearchActivity : AppCompatActivity() {
             try {
                 val responseList = postManager.startSearchStringFeed(
                     cursorId,
-                    4,
+                    ValueUtil.FEED_SIZE,
                     searchContent,
                     sortDialog.sortIndex,
                     filterDialog.sellState,
@@ -269,7 +269,7 @@ class FeedSearchActivity : AppCompatActivity() {
             try {
                 val responseList = postManager.startSearchHashtagFeed(
                     cursorId,
-                    4,
+                    ValueUtil.FEED_SIZE,
                     hashtagContent,
                     sortDialog.sortIndex,
                     filterDialog.sellState,
@@ -308,7 +308,7 @@ class FeedSearchActivity : AppCompatActivity() {
             try {
                 val responseList = UserProfile(this@FeedSearchActivity)
                     .startGetUserSearch(
-                        cursorId, 4, userContent, token
+                        cursorId, ValueUtil.FEED_SIZE, userContent, token
                     ) // 유저 검색 요청하여 리스트 가져오기
                 last(responseList) // 후처리 함수 호출
             } catch (e: ResponseErrorException) {

--- a/Breaking/app/src/main/java/com/dope/breaking/FeedSearchActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/FeedSearchActivity.kt
@@ -1,0 +1,497 @@
+package com.dope.breaking
+
+import android.content.Context
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.text.Editable
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.TextWatcher
+import android.text.style.ForegroundColorSpan
+import android.view.KeyEvent
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import android.widget.LinearLayout
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.dope.breaking.adapter.FeedAdapter
+import com.dope.breaking.adapter.UserSearchAdapter
+import com.dope.breaking.databinding.ActivityFeedSearchBinding
+import com.dope.breaking.exception.ResponseErrorException
+import com.dope.breaking.model.response.ResponseMainFeed
+import com.dope.breaking.model.response.ResponseUserSearch
+import com.dope.breaking.post.PostManager
+import com.dope.breaking.user.UserProfile
+import com.dope.breaking.util.DialogUtil
+import com.dope.breaking.util.JwtTokenUtil
+import com.dope.breaking.util.ValueUtil
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class FeedSearchActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityFeedSearchBinding
+    private var searchState = 0 // 검색 카테고리
+    private val postManager = PostManager()
+    private lateinit var feedAdapter: FeedAdapter // 피드 리스트 어댑터
+    private lateinit var userAdapter: UserSearchAdapter // 유저 검색 리스트 어댑터
+    private lateinit var filterDialog: DialogUtil.FilterOptionDialog // 필터 dialog
+    private lateinit var sortDialog: DialogUtil.SortOptionDialog // 정렬 dialog
+    private var searchContent: String = "" // 문자열 검색인 경우 검색 키워드
+    private var hashtagContent: String = "" // 해시태그 검색인 경우 검색 키워드
+    private var userContent: String = "" // 유저 검색인 경우 검색 키워드
+    private val feedList = mutableListOf<ResponseMainFeed?>() // 피드 리스트
+    private val userList = mutableListOf<ResponseUserSearch?>() // 유저 검색 리스트
+    private var isObtainedAll = false // 모두 다 받아와졌는지 판단
+    private var isLoading = false // 로딩 중 판단
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityFeedSearchBinding.inflate(layoutInflater)
+
+        feedAdapter = FeedAdapter(this, feedList) // 피드 어댑터
+        userAdapter = UserSearchAdapter(this, userList) // 유저 검색 어댑터
+
+        // 리사이클러뷰 divider 지정
+        binding.rcvSearchList.addItemDecoration(
+            DividerItemDecoration(
+                this,
+                LinearLayout.VERTICAL
+            )
+        )
+
+        // 요청 토큰
+        val token = ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(this).getAccessTokenFromLocal()
+
+        // 검색창 입력 감지
+        val textWatcher = object : TextWatcher {
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+                if (p0!!.isNotEmpty()) { // 입력내용이 비어있지 않다면
+                    if (p0[0] == '#') { // 첫 글자가 # 이라면
+                        searchState = 1 // 해시태그 검색 처리
+                        binding.btnMainFilter.isEnabled = true
+                        binding.btnMainSort.isEnabled = true
+                        binding.etSearchBar.setTextColor(getColor(R.color.sign_up_user_type_text_color))
+                        binding.etSearchBar.setBackgroundResource(R.drawable.hashtag_search_input_background)
+                    } else if (p0[0] == '@') { // 첫 글자가 @ 이라면
+                        searchState = 2 // 유저 검색 처리
+                        binding.btnMainFilter.isEnabled = false
+                        binding.btnMainSort.isEnabled = false
+                        binding.etSearchBar.setTextColor(getColor(R.color.teal_700))
+                        binding.etSearchBar.setBackgroundResource(R.drawable.user_search_input_background)
+                    } else { // 둘다 아니라면
+                        searchState = 0 // 일반 게시글 검색 처리
+                        binding.btnMainFilter.isEnabled = true
+                        binding.btnMainSort.isEnabled = true
+                        binding.etSearchBar.setTextColor(getColor(R.color.black))
+                        binding.etSearchBar.setBackgroundResource(R.drawable.input_background)
+                    }
+                } else {
+                    searchState = 0
+                    binding.btnMainFilter.isEnabled = true
+                    binding.btnMainSort.isEnabled = true
+                    binding.etSearchBar.setBackgroundResource(R.drawable.input_background)
+                }
+            }
+
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+
+            }
+
+            override fun afterTextChanged(p0: Editable?) {
+
+            }
+        }
+
+        // 뒤로가기 버튼 클릭 이벤트
+        binding.ibBackButton.setOnClickListener {
+            finish()
+        }
+
+        // 필터 옵션 다이얼로그
+        filterDialog = DialogUtil().FilterOptionDialog(this) {
+            searchFeed(0, token) // 현재 카테고리에 따른 검색 시작
+        }
+
+        // 정렬 옵션 다이얼로그
+        sortDialog = DialogUtil().SortOptionDialog(this) {
+            binding.btnMainSort.text =
+                getString(ValueUtil.SORT_OPTIONS_VIEW[sortDialog.sortIndex]) // 버튼 텍스트 변경
+            searchFeed(0, token) // 현재 카테고리에 따른 검색 시작
+        }
+        // 정렬 옵션 버튼 클릭 이벤트
+        binding.btnMainSort.setOnClickListener {
+            sortDialog.show() // 다이얼로그 실행
+        }
+
+        // 필터 옵션 버튼 클릭 이벤트
+        binding.btnMainFilter.setOnClickListener {
+            filterDialog.show() // 다이얼로그 실행
+        }
+
+        binding.etSearchBar.addTextChangedListener(textWatcher) // 텍스트 감지 리스너 등록
+
+        // 키보드에서 검색 버튼 클릭 시 이벤트
+        binding.etSearchBar.setOnKeyListener { view, i, keyEvent ->
+            // 클릭했다면
+            if ((keyEvent.action == KeyEvent.ACTION_DOWN) && i == KeyEvent.KEYCODE_ENTER) {
+                closeKeyboard(view) // 키보드 닫기
+                searchFeed(0, token) // 검색 시작
+                true
+            } else {
+                false
+            }
+        }
+
+        // 리사이클러뷰 스크롤 이벤트 등록
+        binding.rcvSearchList.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                super.onScrollStateChanged(recyclerView, newState)
+
+                // 리스트의 마지막 인덱스 구하기
+                val lastIndex =
+                    (recyclerView.layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition()
+
+                // 가져온 아이템 개수가 가져와야할 아이템 개수보다 적을 경우 스크롤 이벤트 무시
+                if (recyclerView.adapter!!.itemCount < 4) {
+                    return
+                }
+
+                if (lastIndex == recyclerView.adapter!!.itemCount - 1 && newState == 2 && !isObtainedAll && !isLoading) {
+                    // 커서 id는 검색 카테고리에 따라 다르게 할당 (피드: postId, 유저: userId)
+                    val currentCursor = if (searchState != 2) {
+                        feedAdapter.addItem(null)
+                        feedList[lastIndex]!!.postId
+                    } else {
+                        userAdapter.addItem(null)
+                        userList[lastIndex]!!.userId.toInt()
+                    }
+
+                    // 리스트에 새로운 내용을 append 하도록 하는 검색 요청
+                    searchFeed(currentCursor, token, {
+                        if (searchState != 2) { // 게시글 검색이라면
+                            val list = it as List<ResponseMainFeed> // 데이터 타입 변환
+                            if (list.size < 4) { // 정량으로 가져오는 개수보다 적다면
+                                feedAdapter.removeLast() // 로딩 아이템 제거
+                                isObtainedAll = true // 더 이상 받아올 피드가 없다는 상태로 전환
+                            } else { // 리스트가 있다면
+                                feedAdapter.removeLast() // 먼저 로딩 아이템 제거
+                            }
+                        } else { // 유저 검색이라면
+                            val list = it as List<ResponseUserSearch> // 데이터 타입 변환
+                            if (list.size < 4) { // 정량으로 가져오는 개수보다 적다면
+                                userAdapter.removeLast() // 로딩 아이템 제거
+                                isObtainedAll = true // 더 이상 받아올 피드가 없다는 상태로 전환
+                            } else { // 리스트가 있다면
+                                userAdapter.removeLast() // 먼저 로딩 아이템 제거
+                            }
+                        }
+                    }, true)
+                }
+            }
+        })
+        setContentView(binding.root)
+    }
+
+    /**
+     * 키보드를 닫는 함수
+     * @param view(View): EditText
+     * @author Seunggun Sin
+     * @since 2022-08-30
+     */
+    private fun closeKeyboard(view: View) {
+        val inputManager =
+            this.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        inputManager.hideSoftInputFromWindow(view.windowToken, 0)
+    }
+
+
+    /**
+     * 피드 문자열 검색을 요청하는 프로세스 함수
+     * @param cursorId(Int): 마지막으로 요청한 리스트의 마지막 인덱스의 게시글 아이디
+     * @param token(String): 본인의 Jwt 토큰
+     * @param init(() -> Unit): 요청 전 함수
+     * @param last((List<ResponseMainFeed>) -> Unit): 요청 후 함수
+     * @param error((ResponseErrorException) -> Unit): 에러 발생 시 함수
+     * @author Seunggun Sin
+     * @since 2022-08-30
+     */
+    private fun processStringSearchFeed(
+        cursorId: Int,
+        token: String,
+        init: () -> Unit,
+        last: (List<ResponseMainFeed>) -> Unit,
+        error: (ResponseErrorException) -> Unit
+    ) {
+        CoroutineScope(Dispatchers.Main).launch {
+            init() // 초기 함수 호출
+            searchContent = binding.etSearchBar.text.toString() // 문자열 검색 키워드에 입력한 값 저장
+            try {
+                val responseList = postManager.startSearchStringFeed(
+                    cursorId,
+                    4,
+                    searchContent,
+                    sortDialog.sortIndex,
+                    filterDialog.sellState,
+                    filterDialog.startDate,
+                    filterDialog.endDate,
+                    filterDialog.lastMin,
+                    token
+                ) // 문자열 검색 요청하여 리스트 받아오기
+                last(responseList) // 후처리 함수 호출
+            } catch (e: ResponseErrorException) {
+                error(e) // 에러 함수 호출
+            }
+        }
+    }
+
+    /**
+     * 피드 해시태그 검색을 요청하는 프로세스 함수
+     * @param cursorId(Int): 마지막으로 요청한 리스트의 마지막 인덱스의 게시글 아이디
+     * @param token(String): 본인의 Jwt 토큰
+     * @param init(() -> Unit): 요청 전 함수
+     * @param last((List<ResponseMainFeed>) -> Unit): 요청 후 함수
+     * @param error((ResponseErrorException) -> Unit): 에러 발생 시 함수
+     * @author Seunggun Sin
+     * @since 2022-08-30
+     */
+    private fun processHashtagSearchFeed(
+        cursorId: Int,
+        token: String,
+        init: () -> Unit,
+        last: (List<ResponseMainFeed>) -> Unit,
+        error: (ResponseErrorException) -> Unit
+    ) {
+        CoroutineScope(Dispatchers.Main).launch {
+            init() // 초기 함수 호출
+            hashtagContent = binding.etSearchBar.text.toString() // 해시태그 키워드에 입력한 값 저장
+            try {
+                val responseList = postManager.startSearchHashtagFeed(
+                    cursorId,
+                    4,
+                    hashtagContent,
+                    sortDialog.sortIndex,
+                    filterDialog.sellState,
+                    filterDialog.startDate,
+                    filterDialog.endDate,
+                    filterDialog.lastMin,
+                    token
+                ) // 해시태그 검색 요청하여 리스트 가져오기
+                last(responseList) // 후처리 함수 호출
+            } catch (e: ResponseErrorException) {
+                error(e) // 에러 함수 호출
+            }
+        }
+    }
+
+    /**
+     * 유저 검색을 요청하는 프로세스 함수
+     * @param cursorId(Int): 마지막으로 요청한 리스트의 마지막 인덱스의 유저 아이디
+     * @param token(String): 본인의 Jwt 토큰
+     * @param init(() -> Unit): 요청 전 함수
+     * @param last((List<ResponseUserSearch>) -> Unit): 요청 후 함수
+     * @param error((ResponseErrorException) -> Unit): 에러 발생 시 함수
+     * @author Seunggun Sin
+     * @since 2022-08-30
+     */
+    private fun processUserSearch(
+        cursorId: Int,
+        token: String,
+        init: () -> Unit,
+        last: (List<ResponseUserSearch>) -> Unit,
+        error: (ResponseErrorException) -> Unit
+    ) {
+        CoroutineScope(Dispatchers.Main).launch {
+            init() // 초기 함수 호출
+            userContent = binding.etSearchBar.text.toString() // 유저 키워드에 입력한 값 저장
+            try {
+                val responseList = UserProfile(this@FeedSearchActivity)
+                    .startGetUserSearch(
+                        cursorId, 4, userContent, token
+                    ) // 유저 검색 요청하여 리스트 가져오기
+                last(responseList) // 후처리 함수 호출
+            } catch (e: ResponseErrorException) {
+                error(e) // 에러 함수 호출
+            }
+        }
+    }
+
+    /**
+     * 검색 카테고리에 따라 검색 요청을 하고, view 처리 및 리스트 처리를 해주는 묶음 함수
+     * @param currentCursor(Int): 현재 커서 id
+     * @param token(String): Jwt 토큰
+     * @param init((Any) -> Unit): 응답받고 난 뒤, 호출하여 각 상황에 맞게 처리하는 커스텀 함수
+     * @param append(Boolean): 리스트를 덧붙이는 것인지, 초기화하는 것인지 구분
+     * @author Seunggun Sin
+     * @since 2022-08-30
+     */
+    private fun searchFeed(
+        currentCursor: Int,
+        token: String,
+        init: (Any) -> Unit = {},
+        append: Boolean = false
+    ) {
+        if (!append) // 초기화하는 상태라면
+            isObtainedAll = false // 더 이상 받을 것이 없는 상태 초기화
+
+        // 검색 카테고리 케이스 구분
+        when (searchState) {
+            0 -> { // 일반 게시글 검색
+                if (binding.etSearchBar.text.toString().isNotEmpty()) // 입력 값이 있다면
+                // 문자열 검색 요청
+                    processStringSearchFeed(currentCursor, token, {
+                        if (!append) { // 초기화하는 상태, 즉, 새로 받아오는 요청인 경우
+                            // 로딩 처리
+                            binding.progressSearch.visibility = View.VISIBLE
+                            binding.rcvSearchList.visibility = View.GONE
+                        }
+                    }, {
+                        init(it) // 스크롤 이벤트에 쓰이는 함수 호출
+                        if (append) { // 덧붙이는 것이라면
+                            feedAdapter.addItems(it) // 그대로 리스트에 추가
+                        } else { // 새로 요청 받는 것이라면
+                            binding.rcvSearchList.adapter = feedAdapter // 어댑터 초기화
+                            feedAdapter.replaceAll(it) // 아이템 대체
+                            binding.progressSearch.visibility = View.GONE
+                            binding.rcvSearchList.visibility = View.VISIBLE
+                        }
+
+                        // 나머지 view 처리들
+                        binding.tvSearchResult.visibility = View.VISIBLE
+                        binding.interDividerTop.visibility = View.VISIBLE
+                        binding.interDividerBottom.visibility = View.VISIBLE
+
+                        // 검색 결과에 대한 텍스트 처리
+                        spanningSearchResult()
+
+                        // 리스트가 비어있다면 비어있는 view 처리
+                        if (it.isEmpty())
+                            binding.tvNoResult.visibility = View.VISIBLE
+                        else
+                            binding.tvNoResult.visibility = View.GONE
+
+                    }, {
+                        it.printStackTrace()
+                    })
+            }
+            1 -> { // 해시태그 검색
+                if (binding.etSearchBar.text.toString().length > 1) // 적어도 #을 포함하여 2글자 이상이여야 가능
+                // 해시태그 검색 요청
+                    processHashtagSearchFeed(currentCursor, token, {
+                        if (!append) { // 새로 받아오는 경우
+                            // 로딩 처리
+                            binding.progressSearch.visibility = View.VISIBLE
+                            binding.rcvSearchList.visibility = View.GONE
+                        }
+                    }, {
+                        init(it) // 스크롤 이벤트 처리
+                        if (append) { // 덧붙이는 것이라면
+                            feedAdapter.addItems(it) // 리스트에 추가
+                        } else { // 새로 요청하는 것이라면
+                            binding.rcvSearchList.adapter = feedAdapter // 어댑터 초기화
+                            feedAdapter.replaceAll(it) // 아이템 대체
+                            binding.progressSearch.visibility = View.GONE
+                            binding.rcvSearchList.visibility = View.VISIBLE
+                        }
+
+                        // 나머지 view 처리
+                        binding.tvSearchResult.visibility = View.VISIBLE
+                        binding.interDividerTop.visibility = View.VISIBLE
+                        binding.interDividerBottom.visibility = View.VISIBLE
+
+                        // 검색 결과에 대한 텍스트 처리
+                        spanningSearchResult()
+
+                        // 리스트가 비어있다면 비어있는 view 처리
+                        if (it.isEmpty())
+                            binding.tvNoResult.visibility = View.VISIBLE
+                        else
+                            binding.tvNoResult.visibility = View.GONE
+
+                    }, {
+                        it.printStackTrace()
+                    })
+            }
+            2 -> { // 유저 검색
+                if (binding.etSearchBar.text.toString().length > 1) { // 적어도 @을 포함하여 2글자 이상이여야 가능
+                    // 유저 검색 요청
+                    processUserSearch(currentCursor, token, {
+                        if (!append) { // 새로 받아오는 것이라면
+                            // 로딩 처리
+                            binding.progressSearch.visibility = View.VISIBLE
+                            binding.rcvSearchList.visibility = View.GONE
+                        }
+
+                    }, {
+                        init(it) // 스크롤 이벤트 처리
+                        if (append) { // 덧붙이는 것이라면
+                            userAdapter.addItems(it) // 리스트에 추가
+                        } else {
+                            binding.rcvSearchList.adapter = userAdapter // 어댑터 초기화
+                            userAdapter.replaceAll(it) // 아이템 대체
+                            binding.progressSearch.visibility = View.GONE
+                            binding.rcvSearchList.visibility = View.VISIBLE
+                        }
+
+                        // 나머지 view 처리
+                        binding.tvSearchResult.visibility = View.VISIBLE
+                        binding.interDividerTop.visibility = View.VISIBLE
+                        binding.interDividerBottom.visibility = View.VISIBLE
+
+                        // 검색 결과에 대한 텍스트 처리
+                        spanningSearchResult()
+
+                        // 리스트가 비어있다면 비어있는 view 처리
+                        if (it.isEmpty())
+                            binding.tvNoResult.visibility = View.VISIBLE
+                        else
+                            binding.tvNoResult.visibility = View.GONE
+                    }, {
+                        it.printStackTrace()
+                    })
+                }
+            }
+        }
+    }
+
+    /**
+     * 검색 결과에 대한 텍스트 spanning 처리
+     * @author Seunggun Sin
+     * @since 2022-08-30
+     */
+    private fun spanningSearchResult() {
+        var target = "" // 검색 카테고리
+        var color = 0 // 색상 리소스 id
+        var inter = "" // 카테고리에 따른 검색 결과 안내 텍스트
+        when (searchState) {
+            0 -> { // 게시글 검색
+                target = searchContent
+                color = R.color.breaking_color
+                inter = ""
+            }
+            1 -> { // 해시태그 검색
+                target = hashtagContent
+                color = R.color.breaking_color
+                inter = " 해시태그"
+            }
+            2 -> { // 유저 검색
+                target = userContent
+                color = R.color.teal_700
+                inter = " 유저"
+            }
+        }
+        val tmp = "\"$target\" $inter 검색 결과" // 최종 검색 결과 텍스트
+        val spannableString = SpannableString(tmp)
+        val index = tmp.indexOf(target) // 검색 키워드 시작 인덱스 추출
+
+        spannableString.setSpan(
+            ForegroundColorSpan(getColor(color)),
+            index,
+            index + target.length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        ) // 검색 키워드만 지정한 색깔로 처리
+
+        binding.tvSearchResult.text = spannableString
+    }
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/adapter/UserSearchAdapter.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/adapter/UserSearchAdapter.kt
@@ -1,0 +1,243 @@
+package com.dope.breaking.adapter
+
+import android.app.Activity
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.dope.breaking.R
+import com.dope.breaking.follow.Follow
+import com.dope.breaking.model.response.ResponseExistLogin
+import com.dope.breaking.model.response.ResponseUserSearch
+import com.dope.breaking.user.UserProfile
+import com.dope.breaking.util.DialogUtil
+import com.dope.breaking.util.JwtTokenUtil
+import com.dope.breaking.util.ValueUtil
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class UserSearchAdapter(
+    private val context: Context, // 컨텍스트
+    var data: MutableList<ResponseUserSearch?> // 리스트
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return if (viewType == ValueUtil.VIEW_TYPE_ITEM) {
+            val view =
+                LayoutInflater.from(context).inflate(R.layout.item_user_search, parent, false)
+            ItemViewHolder(view)
+        } else {
+            val view = LayoutInflater.from(context).inflate(R.layout.item_loading, parent, false)
+            LoadingViewHolder(view)
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        if (holder is UserSearchAdapter.ItemViewHolder) {
+            holder.bind(data[position]!!) // view 바인딩
+
+            // 닉네임 클릭 시
+            holder.textNickname.setOnClickListener {
+                UserProfile(context as Activity).moveToUserPage(data[position]!!.userId)
+            }
+            // 프로필 이미지 클릭 시
+            holder.imageProfile.setOnClickListener {
+                UserProfile(context as Activity).moveToUserPage(data[position]!!.userId)
+            }
+            // 리스트 상에서 본인이 들어가 있는 경우 버튼 hidden
+            holder.removeButton.visibility =
+                if (data[position]!!.userId == ResponseExistLogin.baseUserInfo?.userId) View.GONE else View.VISIBLE
+
+            val token =
+                ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(context).getAccessTokenFromLocal() // 요청 토큰
+
+            // 로그인, 비로그인 구분
+            if (ResponseExistLogin.baseUserInfo != null && JwtTokenUtil(context).getAccessTokenFromLocal() != "") {
+                if (data[position]!!.userId == ResponseExistLogin.baseUserInfo?.userId) { // 현재 아이템이 본인이라면
+                    holder.removeButton.visibility = View.GONE // 우측 버튼 숨김
+                } else { // 아니라면
+                    if (data[position]!!.isFollowing) { // 내가 팔로우한 관계라면
+                        convertToFollowingState(holder.removeButton) // 팔로잉 view 처리
+                    } else { // 아니라면
+                        convertToFollowState(holder.removeButton) // 팔로우 view 처리
+                    }
+                    // 우측 버튼 클릭 이벤트
+                    holder.removeButton.setOnClickListener {
+                        clickFollowStateButton(position, token, holder)
+                    }
+                }
+            } else // 비로그인 유저의 경우
+                holder.removeButton.visibility = View.GONE // 우측 버튼 숨김
+        }
+    }
+
+    /**
+     * 리스트에서 각 사람과의 팔로우관계에 따른 클릭 이벤트 (팔로잉 & 팔로우 버튼)
+     * @param position(Int): 현재 리스트에서 클릭한 위치
+     * @param token(String): Jwt 토큰
+     * @param holder(ViewHolder): view holder
+     * @author Seunggun Sin
+     * @since 2022-08-31
+     */
+    private fun clickFollowStateButton(
+        position: Int,
+        token: String,
+        holder: UserSearchAdapter.ItemViewHolder
+    ) {
+        if (data[position]!!.isFollowing) { // 팔로우 중이라면
+            DialogUtil().MultipleDialog(
+                context,
+                "정말 '${data[position]!!.nickname}'님의 팔로우를 취소하시겠습니까?",
+                "예",
+                "아니오",
+                {
+                    CoroutineScope(Dispatchers.Main).launch {
+                        val result =
+                            Follow().startUnFollowRequest(
+                                token,
+                                data[position]!!.userId
+                            ) // 언팔로우 요청
+                        if (result) { // 언팔로우 요청 성공 시
+                            convertToFollowState(holder.removeButton) // 버튼 상태 전환
+                            data[position]!!.isFollowing = false // 팔로잉 상태로 전환
+                        } else
+                            dialogRequestFail() // 실패에 대한 다이얼로그
+                    }
+                }).show()
+        } else { // 팔로우 중이 아니라면
+            CoroutineScope(Dispatchers.Main).launch {
+                val result =
+                    Follow().startFollowRequest(token, data[position]!!.userId) // 팔로우 요청
+                if (result) { // 팔로우 요청 성공 시
+                    convertToFollowingState(holder.removeButton) // 버튼 상태 전환
+                    data[position]!!.isFollowing = true // 팔로우 상태로 전환
+                } else
+                    dialogRequestFail() // 실패에 대한 다이얼로그
+            }
+        }
+    }
+
+    /**
+     * "팔로우" 버튼 상태로 전환(텍스트, 배경 변경)
+     * @param button(Button): 우측 버튼 view
+     * @author Seunggun Sin
+     * @since 2022-08-31
+     */
+    private fun convertToFollowState(button: Button) {
+        button.text = "팔로우"
+        button.setBackgroundResource(R.drawable.sign_up_user_type_unselected)
+    }
+
+    /**
+     * "팔로잉" 버튼 상태로 전환(텍스트, 배경 변경)
+     * @param button(Button): 우측 버튼 view
+     * @author Seunggun Sin
+     * @since 2022-08-31
+     */
+    private fun convertToFollowingState(button: Button) {
+        button.text = "팔로잉"
+        button.setBackgroundResource(R.drawable.feed_category_button_background)
+    }
+
+    /**
+     * 팔로우, 언팔로우 요청 실패시 띄우는 dialog
+     * @author Seunggun Sin
+     * @since 2022-08-31
+     */
+    private fun dialogRequestFail() {
+        DialogUtil().SingleDialog(context, "요청에 실패하였습니다. 재시도 바랍니다.", "확인").show()
+    }
+
+    override fun getItemCount(): Int {
+        return data.size
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return if (data[position] == null) ValueUtil.VIEW_TYPE_LOADING else ValueUtil.VIEW_TYPE_ITEM
+    }
+
+    inner class ItemViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val textNickname: TextView = itemView.findViewById(R.id.tv_user_search_nickname)
+        private val textStatus: TextView = itemView.findViewById(R.id.tv_user_search_status)
+        val imageProfile: ImageView = itemView.findViewById(R.id.imgv_user_search_profile)
+        val removeButton: Button = itemView.findViewById(R.id.btn_user_search_remove)
+        val email: TextView = itemView.findViewById(R.id.tv_user_search_email)
+        val follower: TextView = itemView.findViewById(R.id.tv_user_search_follower)
+
+        fun bind(item: ResponseUserSearch) {
+            textNickname.text = item.nickname
+            textStatus.text = item.statusMsg
+            email.text = item.email
+            follower.text = "팔로워 ${item.followerCount}명"
+
+            if (item.profileImgURL != null)
+                Glide.with(itemView)
+                    .load(ValueUtil.IMAGE_BASE_URL + item.profileImgURL)
+                    .placeholder(R.drawable.ic_default_profile_image)
+                    .circleCrop()
+                    .error(R.drawable.ic_default_profile_image)
+                    .into(imageProfile)
+            else
+                Glide.with(itemView)
+                    .load(R.drawable.ic_default_profile_image)
+                    .circleCrop()
+                    .into(imageProfile)
+        }
+
+    }
+
+    inner class LoadingViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        private val progressDialog = itemView.findViewById<ProgressBar>(R.id.progressbar_loading)
+    }
+
+    /**
+     * 응답으로 받아온 리스트를 리스트에 추가하는 함수
+     * @param items(List<FollowData>): 팔로우 데이터 리스트
+     * @author Seunggun Sin
+     * @since 2022-08-31
+     */
+    fun addItems(items: List<ResponseUserSearch>) {
+        data.addAll(items)
+        notifyItemRangeInserted(itemCount, items.size)
+    }
+
+    /**
+     * 응답으로 받아온 데이터를 리스트에 추가하는 함수
+     * @param item(FollowData): 팔로우 데이터
+     * @author Seunggun Sin
+     * @since 2022-08-31
+     */
+    fun addItem(item: ResponseUserSearch?) {
+        data.add(item)
+        notifyItemInserted(itemCount)
+    }
+
+    /**
+     * 리스트의 마지막 아이템을 지우는 함수
+     * @author Seunggun Sin
+     * @since 2022-08-31
+     */
+    fun removeLast() {
+        data.removeAt(data.size - 1)
+        notifyItemRemoved(data.size)
+    }
+
+    /**
+     * 현재 아이템을 새로운 아이템으로 대체하는 함수
+     * @author Seunggun Sin
+     * @since 2022-08-31
+     */
+    fun replaceAll(items: List<ResponseUserSearch>) {
+        data.clear()
+        data.addAll(items)
+        notifyDataSetChanged()
+    }
+
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviHomeFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviHomeFragment.kt
@@ -3,6 +3,7 @@ package com.dope.breaking.fragment
 import android.Manifest
 import android.content.Intent
 import android.os.Bundle
+import android.text.InputType
 import android.util.Log
 import android.view.*
 import android.widget.LinearLayout
@@ -14,6 +15,7 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.dope.breaking.FeedSearchActivity
 import com.dope.breaking.adapter.FeedAdapter
 import com.dope.breaking.board.PostActivity
 import com.dope.breaking.board.PostDetailActivity
@@ -51,6 +53,11 @@ class NaviHomeFragment : Fragment() {
         // 요청 Jwt 토큰 가져오기
         val token =
             ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(requireContext()).getAccessTokenFromLocal()
+        binding.etSearchBar.inputType = InputType.TYPE_NULL
+
+        binding.etSearchBar.setOnClickListener {
+            startActivity(Intent(requireContext(), FeedSearchActivity::class.java))
+        }
 
         // 피드 요청 에러 시 띄워줄 다이얼로그 정의
         val requestErrorDialog =
@@ -261,7 +268,7 @@ class NaviHomeFragment : Fragment() {
                                 binding.tvNoFeedAlert.visibility = View.GONE
                                 binding.rcvMainFeed.visibility = View.VISIBLE
                             }
-                            
+
                             dismissSkeletonView() // 스켈레톤 UI 종료
 
                             // 다시 false 로 변경

--- a/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseUserSearch.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseUserSearch.kt
@@ -1,0 +1,14 @@
+package com.dope.breaking.model.response
+
+import com.google.gson.annotations.SerializedName
+
+data class ResponseUserSearch(
+    @SerializedName("userId") val userId: Long,
+    @SerializedName("profileImgURL") val profileImgURL: String?,
+    @SerializedName("nickname") val nickname: String,
+    @SerializedName("email") val email: String,
+    @SerializedName("role") val role: String,
+    @SerializedName("statusMsg") val statusMsg: String,
+    @SerializedName("followerCount") val followerCount: Long,
+    @SerializedName("isFollowing") var isFollowing: Boolean,
+)

--- a/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
@@ -99,7 +99,7 @@ interface RetrofitService {
     @GET("post/{postId}")
     suspend fun requestPostDetail(
         @Header("authorization") token: String,
-        @Path("postId") postId : Long
+        @Path("postId") postId: Long
     ): Response<ResponsePostDetail>
 
     /**
@@ -167,6 +167,8 @@ interface RetrofitService {
      * @param token(String): Jwt 토큰 - 헤더 (옵션)
      * @param lastPostId(Int): 마지막으로 가져온 post id (필수) (처음 요청 시에는 0 or null)
      * @param contentsSize(Int): 가져올 게시글 개수 (필수)
+     * @param searchContent(String?): 문자열 검색 키워드 (옵션)
+     * @param hashtagContent(String?): 해시태그 검색 키워드 (옵션)
      * @param sortCategory(String?): 정렬 - 정렬 카테고리 (옵션)
      * @param soldOption(String?): 필터 - 판매 상태 (옵션)
      * @param dateFrom(String?): 필터 - 시작 날짜 (옵션)
@@ -180,6 +182,8 @@ interface RetrofitService {
         @Header("authorization") token: String = "",
         @Query("cursor") lastPostId: Int,
         @Query("size") contentsSize: Int,
+        @Query("search") searchContent: String? = null,
+        @Query("hashtag") hashtagContent: String? = null,
         @Query("sort") sortCategory: String? = null,
         @Query("sold-option") soldOption: String? = null,
         @Query("date-from") dateFrom: String? = null,
@@ -207,6 +211,23 @@ interface RetrofitService {
         @Query("size") contentSize: Int,
         @Query("sold-option") soldOption: String
     ): Response<List<ResponseMainFeed>>
+
+    /**
+     * 유저 검색을 하는 요청
+     * @header token(String): 본인의 Jwt 토큰
+     * @query searchUser(String): 유저를 검색하고자 하는 검색 키워드
+     * @query cursor(Int): 마지막으로 요청한 리스트의 마지막 인덱스의 userId
+     * @query size(Int): 가져오고자 하는 아이템 개수
+     * @response ResponseUserSearch 리스트
+     * @author Seunggun Sin
+     */
+    @GET("search/user")
+    suspend fun requestUserSearch(
+        @Header("authorization") token: String = "",
+        @Query("search") searchUser: String,
+        @Query("cursor") cursorId: Int,
+        @Query("size") contentSize: Int
+    ): Response<List<ResponseUserSearch>>
 
     /**
      * 게시글의 북마크를 등록하는 요청

--- a/Breaking/app/src/main/java/com/dope/breaking/user/UserProfile.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/user/UserProfile.kt
@@ -10,6 +10,7 @@ import com.dope.breaking.UserPageActivity
 import com.dope.breaking.exception.MissingJwtTokenException
 import com.dope.breaking.exception.ResponseErrorException
 import com.dope.breaking.model.response.DetailUser
+import com.dope.breaking.model.response.ResponseUserSearch
 import com.dope.breaking.model.response.User
 import com.dope.breaking.retrofit.RetrofitManager
 import com.dope.breaking.retrofit.RetrofitService
@@ -131,5 +132,33 @@ class UserProfile(private val activity: Activity) {
         } else {
             throw MissingJwtTokenException("토큰이 없습니다.")
         }
+    }
+
+    /**
+     * 유저 검색을 요청하는 함수
+     * @param cursorId(Int): 마지막으로 요청한 리스트의 마지막 인덱스의 userId
+     * @param contentSize(Int): 가져올 아이템 개수
+     * @param userContent(String): 유저 검색하고자 하는 검색 키워드
+     * @param token(String): 본인의 Jwt 토큰
+     * @return List<ResponseUserSearch>: 유저 검색 응답 DTO 리스트
+     */
+    suspend fun startGetUserSearch(
+        cursorId: Int,
+        contentSize: Int,
+        userContent: String,
+        token: String
+    ): List<ResponseUserSearch> {
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+
+        // @ 제거
+        val replacePrefix = userContent.replace("@", "")
+
+        // 응답 받기
+        val response = service.requestUserSearch(token, replacePrefix, cursorId, contentSize)
+
+        if (response.code() in 200..299)
+            return response.body()!!
+        else
+            throw ResponseErrorException("${response.errorBody()!!.string()}")
     }
 }

--- a/Breaking/app/src/main/res/drawable/hashtag_search_input_background.xml
+++ b/Breaking/app/src/main/res/drawable/hashtag_search_input_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="6dip" />
+    <solid android:color="@color/light_gray" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/breaking_color" />
+</shape>

--- a/Breaking/app/src/main/res/drawable/input_background.xml
+++ b/Breaking/app/src/main/res/drawable/input_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="6dip" />
+    <solid android:color="@color/light_gray" />
+</shape>

--- a/Breaking/app/src/main/res/drawable/main_search_background.xml
+++ b/Breaking/app/src/main/res/drawable/main_search_background.xml
@@ -9,7 +9,7 @@
     <item android:state_pressed="false">
         <shape>
             <corners android:radius="6dip" />
-            <solid android:color="@color/search_background_color" />
+            <solid android:color="@color/light_gray" />
         </shape>
     </item>
 </selector>

--- a/Breaking/app/src/main/res/drawable/user_search_input_background.xml
+++ b/Breaking/app/src/main/res/drawable/user_search_input_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="6dip" />
+    <solid android:color="@color/light_gray" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/teal_700" />
+</shape>

--- a/Breaking/app/src/main/res/layout/activity_feed_search.xml
+++ b/Breaking/app/src/main/res/layout/activity_feed_search.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".FeedSearchActivity">
+
+    <Button
+        android:id="@+id/btn_main_filter"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:background="@drawable/main_button_background"
+        android:drawableStart="@drawable/ic_baseline_tune_24"
+        android:padding="5dp"
+        android:text="@string/filter"
+        android:textSize="11sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintHeight_percent="0.04"
+        app:layout_constraintHorizontal_bias="0.05"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/divider"
+        app:layout_constraintVertical_bias="0.015" />
+
+    <Button
+        android:id="@+id/btn_main_sort"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/main_button_background"
+        android:drawableStart="@drawable/ic_baseline_sort_24"
+        android:padding="5dp"
+        android:text="@string/latest_order"
+        android:textSize="11sp"
+        app:layout_constraintBottom_toBottomOf="@id/btn_main_filter"
+        app:layout_constraintHeight_percent="0.04"
+        app:layout_constraintHorizontal_bias="0.07"
+        app:layout_constraintLeft_toRightOf="@id/btn_main_filter"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="@id/btn_main_filter"
+        app:layout_constraintVertical_bias="0.02"
+        app:layout_constraintWidth_percent="0.25" />
+
+    <EditText
+        android:id="@+id/et_search_bar"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/input_background"
+        android:hint="@string/search_hint_text"
+        android:imeOptions="actionSearch"
+        android:inputType="text"
+        android:maxLines="1"
+        android:padding="3dp"
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="@id/ib_back_button"
+        app:layout_constraintHeight_percent="0.05"
+        app:layout_constraintLeft_toRightOf="@id/ib_back_button"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="@id/ib_back_button"
+        app:layout_constraintWidth_percent="0.85" />
+
+    <ImageButton
+        android:id="@+id/ib_back_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/image_button_click_background"
+        android:src="@drawable/ic_baseline_arrow_back_black_24"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintHorizontal_bias="0.035"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.025" />
+
+    <ProgressBar
+        android:id="@+id/progress_search"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:indeterminateTint="@color/breaking_color"
+        android:visibility="gone"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_search_result"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:elevation="10dp"
+        android:padding="5dp"
+        android:textColor="@color/black"
+        android:textSize="11.5sp"
+        android:textStyle="bold"
+        android:visibility="gone"
+        app:layout_constraintHorizontal_bias="0.18"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/inter_divider_top"
+        app:layout_constraintWidth_percent="0.85" />
+
+    <TextView
+        android:id="@+id/tv_announce_search_hashtag"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="3dp"
+        android:text="@string/hashtag_alert"
+        android:textSize="10sp"
+        android:textStyle="bold"
+        app:layout_constraintHorizontal_bias="0.1"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btn_main_filter"
+        app:layout_constraintVertical_bias="0" />
+
+    <TextView
+        android:id="@+id/tv_announce_search_user"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="3dp"
+        android:text="@string/user_alert"
+        android:textSize="10sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@id/inter_divider_top"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintLeft_toLeftOf="@id/tv_announce_search_hashtag"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_announce_search_hashtag" />
+
+    <TextView
+        android:id="@+id/tv_no_result"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:gravity="center"
+        android:text="@string/no_search_result"
+        android:textColor="@color/black"
+        android:textStyle="bold"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/inter_divider_bottom" />
+
+    <View
+        android:id="@+id/inter_divider_top"
+        android:layout_width="match_parent"
+        android:layout_height="0.4dp"
+        android:background="@color/real_gray"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/tv_search_result"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_announce_search_hashtag" />
+
+    <View
+        android:id="@+id/inter_divider_bottom"
+        android:layout_width="match_parent"
+        android:layout_height="0.4dp"
+        android:background="@color/real_gray"
+        android:visibility="gone"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_search_result" />
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="0.2dp"
+        android:background="@color/real_gray"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/et_search_bar"
+        app:layout_constraintVertical_bias="0.012" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rcv_search_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="3dp"
+        android:overScrollMode="never"
+        android:scrollbarAlwaysDrawVerticalTrack="true"
+        android:scrollbarSize="5dp"
+        android:scrollbars="vertical"
+        android:visibility="gone"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/inter_divider_bottom" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Breaking/app/src/main/res/layout/fragment_navi_home.xml
+++ b/Breaking/app/src/main/res/layout/fragment_navi_home.xml
@@ -47,15 +47,17 @@
             app:layout_constraintWidth_percent="0.25" />
 
         <EditText
-            android:id="@+id/search_bar"
+            android:id="@+id/et_search_bar"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:background="@drawable/main_search_background"
-            android:hint="@string/search_hint_text"
             android:inputType="none"
+            android:focusable="false"
+            android:clickable="true"
+            android:background="@drawable/main_search_background"
             android:textSize="13sp"
+            android:hint="@string/search"
             app:layout_constraintBottom_toBottomOf="@id/imgv_main_logo"
-            app:layout_constraintHeight_percent="0.04"
+            app:layout_constraintHeight_percent="0.05"
             app:layout_constraintHorizontal_bias="0.85"
             app:layout_constraintLeft_toRightOf="@id/imgv_main_logo"
             app:layout_constraintRight_toRightOf="parent"
@@ -68,9 +70,9 @@
             android:layout_height="wrap_content"
             android:background="@drawable/ic_baseline_search_24"
             android:translationZ="10dp"
-            app:layout_constraintBottom_toBottomOf="@id/search_bar"
-            app:layout_constraintRight_toRightOf="@id/search_bar"
-            app:layout_constraintTop_toTopOf="@id/search_bar" />
+            app:layout_constraintBottom_toBottomOf="@id/et_search_bar"
+            app:layout_constraintRight_toRightOf="@id/et_search_bar"
+            app:layout_constraintTop_toTopOf="@id/et_search_bar" />
 
         <ImageView
             android:id="@+id/imgv_main_logo"
@@ -203,7 +205,7 @@
             android:theme="@style/FormButton"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHeight_percent="0.05"
+            app:layout_constraintHeight_percent="0.06"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_bias="0.98"

--- a/Breaking/app/src/main/res/layout/fragment_navi_user.xml
+++ b/Breaking/app/src/main/res/layout/fragment_navi_user.xml
@@ -90,8 +90,8 @@
             app:layout_constraintBottom_toBottomOf="@id/img_view_my_page_profile"
             app:layout_constraintLeft_toLeftOf="@id/tv_my_page_nickname"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="@id/img_view_my_page_profile"
-            app:layout_constraintVertical_bias="0.6" />
+            app:layout_constraintTop_toBottomOf="@id/tv_my_page_nickname"
+            app:layout_constraintVertical_bias="0.2" />
 
         <TextView
             android:id="@+id/tv_follow_title"

--- a/Breaking/app/src/main/res/layout/item_post_list.xml
+++ b/Breaking/app/src/main/res/layout/item_post_list.xml
@@ -40,7 +40,7 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/imgv_post_thumbnail"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_percent="0.3" />
+        app:layout_constraintWidth_percent="0.29" />
 
     <ImageView
         android:id="@+id/imgv_post_location_icon"
@@ -51,7 +51,7 @@
         app:layout_constraintLeft_toLeftOf="@id/tv_post_title"
         app:layout_constraintTop_toTopOf="@id/tv_post_time"
         app:layout_constraintVertical_bias="0.6"
-        app:layout_constraintWidth_percent="0.045" />
+        app:layout_constraintWidth_percent="0.043" />
 
     <ImageView
         android:id="@+id/imgv_comment"
@@ -78,7 +78,7 @@
         android:paddingBottom="2dp"
         android:text="@string/exclusive_string"
         android:textColor="@color/white"
-        android:textSize="9sp"
+        android:textSize="8.5sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@id/imgv_post_thumbnail"
         app:layout_constraintHorizontal_bias="0"
@@ -102,7 +102,7 @@
         android:paddingBottom="2dp"
         android:text="@string/sold_string"
         android:textColor="@color/white"
-        android:textSize="9sp"
+        android:textSize="8.5sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@id/imgv_post_thumbnail"
         app:layout_constraintHorizontal_bias="1"
@@ -124,7 +124,7 @@
         android:paddingBottom="2dp"
         android:text="@string/is_selling_string"
         android:textColor="@color/breaking_color"
-        android:textSize="9sp"
+        android:textSize="8.5sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="@id/imgv_post_thumbnail"
         app:layout_constraintHorizontal_bias="0"
@@ -139,7 +139,7 @@
         android:layout_height="wrap_content"
         android:ellipsize="end"
         android:textColor="@color/black"
-        android:textSize="10sp"
+        android:textSize="9sp"
         android:textStyle="bold"
         app:layout_constraintHorizontal_bias="0.1"
         app:layout_constraintLeft_toRightOf="@id/tv_split_slash"
@@ -155,7 +155,7 @@
         android:layout_marginEnd="3dp"
         android:text="@string/vertical_divider_string"
         android:textColor="@color/black"
-        android:textSize="10sp"
+        android:textSize="9sp"
         app:layout_constraintBottom_toBottomOf="@id/tv_post_time"
         app:layout_constraintHorizontal_bias="0.05"
         app:layout_constraintLeft_toRightOf="@id/tv_post_time"
@@ -203,7 +203,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textColor="@color/breaking_color"
-        android:textSize="10sp"
+        android:textSize="9sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toRightOf="@id/imgv_post_location_icon"
         app:layout_constraintTop_toBottomOf="@id/tv_post_title"
@@ -214,7 +214,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="2dp"
-        android:textSize="10sp"
+        android:textSize="9sp"
         app:layout_constraintLeft_toRightOf="@id/tv_split_dot"
         app:layout_constraintTop_toTopOf="@id/tv_post_location" />
 
@@ -236,7 +236,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textColor="@color/black"
-        android:textSize="13sp"
+        android:textSize="12sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHorizontal_bias="0"

--- a/Breaking/app/src/main/res/layout/item_user_search.xml
+++ b/Breaking/app/src/main/res/layout/item_user_search.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="3dp"
+    android:background="@color/follow_list_background_color"
+    android:padding="8dp">
+
+    <Button
+        android:id="@+id/btn_user_search_remove"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/my_profile_edit_profile_btn_background"
+        android:text="@string/follow_remove"
+        android:textSize="9sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintHeight_percent="0.45"
+        app:layout_constraintHorizontal_bias="0.975"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.65"
+        app:layout_constraintWidth_percent="0.15" />
+
+    <ImageView
+        android:id="@+id/imgv_user_search_profile"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
+        android:scaleType="centerCrop"
+        android:src="@drawable/ic_default_profile_image"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_percent="0.15" />
+
+    <TextView
+        android:id="@+id/tv_user_search_status"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:text="@string/status_msg"
+        android:textColor="@color/black"
+        android:textSize="10.5sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintLeft_toLeftOf="@id/tv_user_search_nickname"
+        app:layout_constraintRight_toLeftOf="@id/btn_user_search_remove"
+        app:layout_constraintTop_toBottomOf="@id/tv_user_search_follower"
+        app:layout_constraintVertical_bias="1" />
+
+    <TextView
+        android:id="@+id/tv_user_search_email"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="9sp"
+        app:layout_constraintBottom_toBottomOf="@id/tv_user_search_nickname"
+        app:layout_constraintHorizontal_bias="0.06"
+        app:layout_constraintLeft_toRightOf="@id/tv_user_search_nickname"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tv_user_search_nickname" />
+
+    <TextView
+        android:id="@+id/tv_user_search_follower"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="9sp"
+        app:layout_constraintBottom_toBottomOf="@id/imgv_user_search_profile"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintLeft_toLeftOf="@id/tv_user_search_nickname"
+        app:layout_constraintRight_toLeftOf="@id/btn_user_search_remove"
+        app:layout_constraintTop_toBottomOf="@id/tv_user_search_nickname"
+        app:layout_constraintVertical_bias="0.05" />
+
+    <TextView
+        android:id="@+id/tv_user_search_nickname"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/nickname"
+        android:textColor="@color/black"
+        android:textSize="12.5sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/imgv_user_search_profile"
+        app:layout_constraintHorizontal_bias="0.04"
+        app:layout_constraintLeft_toRightOf="@id/imgv_user_search_profile"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.1" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Breaking/app/src/main/res/values/colors.xml
+++ b/Breaking/app/src/main/res/values/colors.xml
@@ -8,8 +8,8 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="gray">#EBE4E4</color>
-    <color name="real_gray">#aaaaaa</color>
-    <color name="light_gray">#dddddd</color>
+    <color name="real_gray">#cccccc</color>
+    <color name="light_gray">#eeeeee</color>
     <color name="breaking_color">#014D91</color>
     <color name="breaking_drawer_color">#2D375B</color>
     <color name="breaking_bottom_clicked_color">#FF9800</color>

--- a/Breaking/app/src/main/res/values/strings.xml
+++ b/Breaking/app/src/main/res/values/strings.xml
@@ -63,7 +63,7 @@
     <string name="dot_divider">·</string>
     <string name="filter">필터</string>
     <string name="latest_order">최신순</string>
-    <string name="search_hint_text">제보를 검색하세요.</string>
+    <string name="search_hint_text"> 제보 또는 유저를 검색하세요.</string>
     <string name="post_detail_tool_bar">제보글</string>
     <string name="post_detail_btn_purchase">구매하기</string>
     <string name="post_detail_btn_sold">구매완료</string>
@@ -95,4 +95,8 @@
     <string name="no_purchased">구매한 제보가 없습니다.</string>
     <string name="no_written">작성한 제보가 없습니다.</string>
     <string name="no_bookmarked">북마크한 제보가 없습니다.</string>
+    <string name="search">검색</string>
+    <string name="hashtag_alert">해시태그 검색 시 맨 앞에 #을 붙여주세요. ex) #해시태그</string>
+    <string name="user_alert">유저 검색 시 맨 앞에 @을 붙여주세요. ex) @홍길동</string>
+    <string name="no_search_result">검색결과 없음</string>
 </resources>


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #88 

## 예상 리뷰 시간
30-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 유저 페이지 xml에서 상태메세지가 길어짐에 따라 닉네임과 겹쳐지는 현상 발생
  - constraint 연결을 수정하고 bias 값 조정함으로써 해결
- 메인 피드에서 검색창 클릭 시, 검색 페이지로 이동
- 피드 아이템에서 제목 제외 모든 텍스트 크기 줄임
- 검색 페이지에서 검색 기능 구현
  - 별도의 페이지를 생성하여 그곳에서만 검색이 가능하도록 함
  - 단순 검색 시, 일반 문자열 게시글 검색 / #을 붙이고 검색 시, 해시태그 게시글 검색 / @를 붙이고 검색 시, 유저 검색으로 구분
  - 문자열 검색과 해시태그 검색의 경우에는 필터, 정렬 옵션이 붙을 수 있어서 메인 피드의 필터, 정렬 버튼 가져와 적용
    - 유저 검색 시에는 비활성화 처리
    - retrofit 요청에도 일반 피드 요청과 검색 요청을 분리해서 만드려고 했으나 하나의 요청으로 합쳐서 구현
  - 유저 검색 시 별도의 유저 검색 아이템을 만들어서 유저 검색 어댑터를 구현함으로써 유저 검색 리스트를 보여주도록 함
    - 기능은 대체적으로 팔로우 리스트와 동일
  - 메인 피드와 동일하게 스크롤 이벤트에 의한 데이터 갱신 기능 구현
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
- 메인 피드에서 우측 상단의 검색 창 
<img src="https://user-images.githubusercontent.com/54919474/187591305-39fd339b-6030-4f5e-ad3d-1c5ab983a673.png" width="30%" height="30%"/>

- 검색 창 클릭 시, 검색 페이지로 이동
<img src="https://user-images.githubusercontent.com/54919474/187591312-789d3f4b-5ed0-4b07-8d41-a9c636b94967.png" width="30%" height="30%"/>

- 일반 게시글 검색 후 결과
<img src="https://user-images.githubusercontent.com/54919474/187591325-7d77c91d-4953-408b-8dcb-52dd46638135.png" width="30%" height="30%"/>

- 해시태그 검색 후 결과
<img src="https://user-images.githubusercontent.com/54919474/187591338-57d6909e-3f31-46ca-bea9-211b230c3fe6.png" width="30%" height="30%"/>

- 유저 검색 후 결과
<img src="https://user-images.githubusercontent.com/54919474/187591350-b58fc6dc-7a2a-43cf-82bc-6e24005dc391.png" width="30%" height="30%"/>

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 메인 피드에서 우측 검색 창을 클릭하면 검색 페이지로 이동하는 것이 의도였다. 그런데, 검색창을 클릭하면 키보드만 뜰뿐, 아무런 클릭 이벤트가 발동되지 않았다. 키보드가 열린 채로 한번 더 클릭 하면 그제서야 클릭 이벤트가 발동되었다. 이 문제는 EditText의 `clickable` 속성에 true값을 줌으로써 해결했다. (기존 클릭이 허용되지 않은 view에서 클릭 이벤트가 지정되었을 때 발생되는 문제인가 싶다.)
- Retrofit API에다가 메인피드 따로, 문자열 검색 따로, 해시태그 따로 구분하려고 했다가, "그럼 문자열 검색이나 해시태그에는 필터나 정렬 옵션이 적용될 수가 없는건가? 있어야될 거 같은데?" 생각이 들어서 백엔드 팀에게 물어본 결과, 적용이 가능하다고 해서 기존 메인 피드 요청에다가 문자열 검색과 해시태그 검색에 대한 request parameter를 추가해준 뒤, 사용할 때는 필요한 것만 골라서 사용하는 식으로 바꾸었다. 
  - 대신 controller 함수는 분리해서 각각에 대한 키워드를 받아서 따로 처리해주었다. 
- 검색 기능에서 원래 의도는 일반 문자열 검색을 하거나 `#`을 붙이면 해시태그 검색을 하도록 하려고 했었다. 그러다가 프론트팀이 만든 기능을 참고하려고 검색 기능을 사용해보았는데, 키워드 하나로 통합검색을 하고, 게시글, 해시태그, 심지어 유저 검색까지도 구현해놓은 상태였다. 
  - 유저 검색은 고려하지를 않아서 고민이 많이 되었다. 따로 뺀다고 해도 유저 검색을 하는 곳을 따로 만들어 둘 곳이 마땅히 없었기에 유저 검색도 같이 할 수 있게 했어야했다. 
  - 그래서 명령어처럼 특정 접두사로 검색을 구분하게 하는 것이 좋을 것 같다고 생각이 들었다. 보통 유저, 사람을 언급할 때 `@`를 많이 사용하므로 `@`을 맨 앞에 붙이면 유저 검색, `#`을 맨 앞에 붙이면 해시태그 검색으로 구분하도록 하였다. 
  - 3가지 경우에 대한 검색을 구분해주면서 스크롤 이벤트까지 고려하려고 하다보니 요청 함수를 만들 필요가 있었다. 그런데, 고려해야할 사항이 한두가지가 아니였다.  
  - 유저 검색의 경우 팔로우 리스트와 다르게 응답 값도 달라서 새로 아이템과 어댑터를 만들고, 기능 자체는 팔로우 리스트와 거의 동일하게 구현하였다. 
  - 이렇게함으로써 검색을 하면 두개의 어댑터가 번갈아가면서 사용이 되어야했다. 
  - 좀 복잡해지지만 경우에 따르는, 다른 검색 키워드로 검색하여 새로 받아오는 경우, 스크롤 이벤트로 데이터 갱신하는 경우를 모두 고려해서 모듈화를 하기 위해 코드가 조금 더럽지만 불가피하게 묶어서 기능을 구현하였다. 