### PR TITLE
 fix : post detail problems

### DIFF
--- a/Breaking/app/src/main/java/com/dope/breaking/board/PostDetailActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/board/PostDetailActivity.kt
@@ -475,10 +475,9 @@ class PostDetailActivity : AppCompatActivity() {
      * @since 2022-08-31
      */
     private fun showSkeletonView() {
-        binding.rvCommentList.visibility = View.INVISIBLE // 댓글 리스트 invisible
-        binding.viewWholeContentLayout.visibility = View.INVISIBLE // 전체 컨텐츠 invisible
-        binding.viewWholeContentLayout.visibility = View.VISIBLE // 스켈레톤 visible
-        binding.sflPostDetailSkeleton.visibility = View.VISIBLE
+        binding.rvCommentList.visibility = View.GONE // 댓글 리스트 invisible
+        binding.viewWholeContentLayout.visibility = View.GONE // 전체 컨텐츠 invisible
+        binding.sflPostDetailSkeleton.visibility = View.VISIBLE // 스켈레톤 visible
         binding.sflPostDetailSkeleton.startShimmer()
     }
 

--- a/Breaking/app/src/main/java/com/dope/breaking/board/PostDetailActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/board/PostDetailActivity.kt
@@ -30,6 +30,7 @@ import com.dope.breaking.util.Utils
 import com.dope.breaking.util.ValueUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.text.DecimalFormat
 import java.time.LocalDateTime
@@ -55,20 +56,18 @@ class PostDetailActivity : AppCompatActivity() {
         var getPostId = intent.getIntExtra("postId",-1)
         Log.d(TAG,"받아온 postId 값 : $getPostId")
 
-        // 게시글 상세 조회 요청 다이얼 로그 시작
-        val progressDialog = DialogUtil().ProgressDialog(this)
-        progressDialog.showDialog()
-
         // 게시글 상세 조회 요청
-        CoroutineScope(Dispatchers.Main).launch {
-            processPostDetail(
-                JwtTokenUtil(applicationContext).getAccessTokenFromLocal(), // 로컬에서 토큰 가져오기
-                getPostId.toLong()
-            )
-            if (progressDialog.isShowing()) { // 로딩 다이얼로그 종료
-                progressDialog.dismissDialog()
+        processPostDetail(
+            JwtTokenUtil(applicationContext).getAccessTokenFromLocal(), // 로컬에서 토큰 가져오기
+            getPostId.toLong(), {
+                showSkeletonView() // 스켈레톤 UI 시작
+            },{
+                dismissSkeletonView() // 스켈레톤 UI 종료
+                settingPostDetailView(it) // 받아온 it을 바탕으로 view에 뿌려주기
+                Log.d(TAG,"visibility 테스트 : ${binding.tvPostContent.visibility}")
+                Log.d(TAG,"값 테스트 : ${binding.tvPostContent.text}")
             }
-        }
+        )
 
         binding.viewPager.offscreenPageLimit = 1 // 한 페이지에 한 이미지만 보여주도록 설정
         binding.viewPager.registerOnPageChangeCallback(object: ViewPager2.OnPageChangeCallback(){ // viewPager2 페이지 변화 감지
@@ -228,27 +227,30 @@ class PostDetailActivity : AppCompatActivity() {
      * @author - Tae hyun Park
      * @since - 2022-08-15
      */
-    private suspend fun processPostDetail(
+    private fun processPostDetail(
         token: String,
-        postId: Long
+        postId: Long,
+        init: () -> Unit,
+        last: (ResponsePostDetail) -> Unit
     ) {
-        val postManager = PostManager() // 커스텀 게시글 객체 생성
-        try {
-            val responsePostDetail = postManager.startGetPostDetail(
-                token,
-                postId
-            )
-            Log.d(TAG, "요청 성공 시 받아온 게시물 제목 : ${responsePostDetail.title}")
-
-            // 받아온 세부 조회 정보를 view 에 보여주기
-            settingPostDetailView(responsePostDetail)
-        } catch (e: ResponseErrorException) {
-            e.printStackTrace()
-            DialogUtil().SingleDialog(
-                this,
-                "게시글 상세 조회 요청에 문제가 발생하였습니다.",
-                "확인"
-            )
+        CoroutineScope(Dispatchers.Main).launch {
+            init() // 초기화 함수 호출
+            val postManager = PostManager() // 커스텀 게시글 객체 생성
+            try {
+                val responsePostDetail = postManager.startGetPostDetail(
+                    token,
+                    postId
+                )
+                Log.d(TAG, "요청 성공 시 받아온 게시물 제목 : ${responsePostDetail.title}")
+                last(responsePostDetail) // 후처리 함수 호출
+            } catch (e: ResponseErrorException) {
+                e.printStackTrace()
+                DialogUtil().SingleDialog(
+                    applicationContext,
+                    "게시글 상세 조회 요청에 문제가 발생하였습니다.",
+                    "확인"
+                )
+            }
         }
     }
 
@@ -286,6 +288,8 @@ class PostDetailActivity : AppCompatActivity() {
             // 게시글 작성자의 프로필 이미지
             Glide.with(applicationContext)
                 .load(R.drawable.ic_default_profile_image)
+                .placeholder(R.drawable.ic_default_profile_image)
+                .error(R.drawable.ic_default_profile_image)
                 .circleCrop()
                 .into(binding.ivProfileWriter)
             // 유저 닉네임
@@ -294,6 +298,8 @@ class PostDetailActivity : AppCompatActivity() {
             // 게시글 작성자의 프로필 이미지
             Glide.with(applicationContext)
                 .load(ValueUtil.IMAGE_BASE_URL + responsePostDetail.user?.profileImgUrl)
+                .placeholder(R.drawable.ic_default_profile_image)
+                .error(R.drawable.ic_default_profile_image)
                 .circleCrop()
                 .into(binding.ivProfileWriter)
             // 유저 닉네임
@@ -370,6 +376,7 @@ class PostDetailActivity : AppCompatActivity() {
     private fun setViewHashTag(responsePostDetail: ResponsePostDetail){
         // 해시 태그 리스트 색상 표시
         Log.d(TAG, "해당 게시물의 해시 태그 리스트 : ${responsePostDetail.hashtagList}")
+        Log.d(TAG, "해당 게시물의 전체 컨텐츠 : ${responsePostDetail.content}")
         var spannableString = SpannableString(responsePostDetail.content) // 텍스트 뷰의 특정 문자열 처리를 위한 spannableString 객체 생성
         var startList = ArrayList<Int>()
         for(hashString in responsePostDetail.hashtagList){
@@ -399,6 +406,7 @@ class PostDetailActivity : AppCompatActivity() {
      * @since - 2022-08-25
      */
     private fun setViewMediaList(responsePostDetail: ResponsePostDetail){
+        Log.d(TAG,"미디어 리스트 URL : ${responsePostDetail.mediaList}")
         // 받아온 mediaList 처리
         if(responsePostDetail.mediaList.size == 0){ // 게시물의 이미지가 없다면
             binding.ivPostDetailDefault.visibility = View.VISIBLE // default 이미지 보여주기
@@ -459,5 +467,32 @@ class PostDetailActivity : AppCompatActivity() {
                 return false
             }
         })
+    }
+
+    /**
+     * 스켈레톤 UI를 보여주는 함수 with shimmer effect
+     * @author Seunggun Sin
+     * @since 2022-08-31
+     */
+    private fun showSkeletonView() {
+        binding.rvCommentList.visibility = View.INVISIBLE // 댓글 리스트 invisible
+        binding.viewWholeContentLayout.visibility = View.INVISIBLE // 전체 컨텐츠 invisible
+        binding.viewWholeContentLayout.visibility = View.VISIBLE // 스켈레톤 visible
+        binding.sflPostDetailSkeleton.visibility = View.VISIBLE
+        binding.sflPostDetailSkeleton.startShimmer()
+    }
+
+    /**
+     * 스켈레톤 UI를 종료하는 함수
+     * @author Seunggun Sin
+     * @since 2022-08-31
+     */
+    private fun dismissSkeletonView() {
+        binding.sflPostDetailSkeleton.stopShimmer()
+        binding.sflPostDetailSkeleton.visibility = View.GONE // 스켈레톤 gone
+        binding.rvCommentList.visibility = View.VISIBLE      // 댓글 리스트 visible
+        binding.viewWholeContentLayout.visibility = View.VISIBLE // 전체 컨텐츠 visible
+        binding.tvPostContent.visibility = View.VISIBLE
+        binding.tvPostContent.text = "테스트테스트"
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviHomeFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviHomeFragment.kt
@@ -64,7 +64,6 @@ class NaviHomeFragment : Fragment() {
                 adapter.clearList()
                 isObtainedAll = false // 더 이상 얻을 피드가 없는 상태 초기화
             }, {
-
                 if (it.isEmpty()) { // 리스트가 비어있다면
                     // 비어있다면 화면 뿌려주기
                     binding.tvNoFeedAlert.visibility = View.VISIBLE

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/BookmarkedTabFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/BookmarkedTabFragment.kt
@@ -1,7 +1,9 @@
 package com.dope.breaking.fragment.user_tab
 
+import android.content.Intent
 import android.graphics.Typeface
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -13,6 +15,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.dope.breaking.R
 import com.dope.breaking.adapter.FeedAdapter
+import com.dope.breaking.board.PostDetailActivity
 import com.dope.breaking.databinding.FragmentBookmarkedTabBinding
 import com.dope.breaking.exception.ResponseErrorException
 import com.dope.breaking.model.response.ResponseMainFeed
@@ -58,6 +61,11 @@ class BookmarkedTabFragment : Fragment() {
             isLoading = true // 로딩 시작 상태
         }, { it ->
             adapter = FeedAdapter(requireContext(), userFeedMutableList) // 우선 어댑터 초기화
+            adapter.setItemListClickListener(object : FeedAdapter.OnItemClickListener {
+                override fun onClick(v: View, position: Int) {
+                    moveToPostDetailPage(position)
+                }
+            })
             binding.rcvUserBookmarked.adapter = adapter // 리사이클러뷰에 적용
 
             if (it.isEmpty()) // 가져온 리스트가 비어있다면
@@ -275,5 +283,17 @@ class BookmarkedTabFragment : Fragment() {
                 error(e) // 에러 함수 호출
             }
         }
+    }
+
+    /**
+     * 어댑터에서 아이템 리스트를 클릭했을 때, 해당 postId를 받아와 세부 조회 액티비티로 넘겨주는 함수
+     * @param position(Int): 현재 리스트의 인덱스
+     * @author Tae hyun Park | Seunggun Sin
+     * @since 2022-08-18 | 2022-08-25
+     */
+    private fun moveToPostDetailPage(position: Int) {
+        val intent = Intent(context, PostDetailActivity::class.java)
+        intent.putExtra("postId", userFeedMutableList[position]!!.postId)
+        startActivity(intent)
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/PostTabFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/PostTabFragment.kt
@@ -1,5 +1,6 @@
 package com.dope.breaking.fragment.user_tab
 
+import android.content.Intent
 import android.graphics.Typeface
 import android.os.Bundle
 import androidx.fragment.app.Fragment
@@ -13,6 +14,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.dope.breaking.R
 import com.dope.breaking.adapter.FeedAdapter
+import com.dope.breaking.board.PostDetailActivity
 import com.dope.breaking.databinding.FragmentPostTabBinding
 import com.dope.breaking.exception.ResponseErrorException
 import com.dope.breaking.model.response.ResponseMainFeed
@@ -58,6 +60,11 @@ class PostTabFragment : Fragment() {
             isLoading = true // 로딩 시작 상태
         }, { it ->
             adapter = FeedAdapter(requireContext(), userFeedMutableList) // 우선 어댑터 초기화
+            adapter.setItemListClickListener(object : FeedAdapter.OnItemClickListener {
+                override fun onClick(v: View, position: Int) {
+                    moveToPostDetailPage(position)
+                }
+            })
             binding.rcvUserWritten.adapter = adapter // 리사이클러뷰에 적용
 
             if (it.isEmpty()) // 가져온 리스트가 비어있다면
@@ -275,5 +282,17 @@ class PostTabFragment : Fragment() {
                 error(e) // 에러 함수 호출
             }
         }
+    }
+
+    /**
+     * 어댑터에서 아이템 리스트를 클릭했을 때, 해당 postId를 받아와 세부 조회 액티비티로 넘겨주는 함수
+     * @param position(Int): 현재 리스트의 인덱스
+     * @author Tae hyun Park | Seunggun Sin
+     * @since 2022-08-18 | 2022-08-25
+     */
+    private fun moveToPostDetailPage(position: Int) {
+        val intent = Intent(context, PostDetailActivity::class.java)
+        intent.putExtra("postId", userFeedMutableList[position]!!.postId)
+        startActivity(intent)
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/PurchasedTabFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/PurchasedTabFragment.kt
@@ -1,5 +1,6 @@
 package com.dope.breaking.fragment.user_tab
 
+import android.content.Intent
 import android.graphics.Typeface
 import android.os.Bundle
 import androidx.fragment.app.Fragment
@@ -13,6 +14,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.dope.breaking.R
 import com.dope.breaking.adapter.FeedAdapter
+import com.dope.breaking.board.PostDetailActivity
 import com.dope.breaking.databinding.FragmentPurchasedTabBinding
 import com.dope.breaking.exception.ResponseErrorException
 import com.dope.breaking.model.response.ResponseMainFeed
@@ -58,6 +60,11 @@ class PurchasedTabFragment : Fragment() {
             isLoading = true // 로딩 시작 상태
         }, { it ->
             adapter = FeedAdapter(requireContext(), userFeedMutableList) // 우선 어댑터 초기화
+            adapter.setItemListClickListener(object : FeedAdapter.OnItemClickListener {
+                override fun onClick(v: View, position: Int) {
+                    moveToPostDetailPage(position)
+                }
+            })
             binding.rcvUserPurchased.adapter = adapter // 리사이클러뷰에 적용
 
             if (it.isEmpty()) // 가져온 리스트가 비어있다면
@@ -275,5 +282,17 @@ class PurchasedTabFragment : Fragment() {
                 error(e) // 에러 함수 호출
             }
         }
+    }
+
+    /**
+     * 어댑터에서 아이템 리스트를 클릭했을 때, 해당 postId를 받아와 세부 조회 액티비티로 넘겨주는 함수
+     * @param position(Int): 현재 리스트의 인덱스
+     * @author Tae hyun Park | Seunggun Sin
+     * @since 2022-08-18 | 2022-08-25
+     */
+    private fun moveToPostDetailPage(position: Int) {
+        val intent = Intent(context, PostDetailActivity::class.java)
+        intent.putExtra("postId", userFeedMutableList[position]!!.postId)
+        startActivity(intent)
     }
 }

--- a/Breaking/app/src/main/res/drawable/bg_indicator_active.xml
+++ b/Breaking/app/src/main/res/drawable/bg_indicator_active.xml
@@ -7,6 +7,6 @@
         android:height="12dp" />
 
     <solid
-        android:color="#6200EE" />
+        android:color="#014D91" />
 
 </shape>

--- a/Breaking/app/src/main/res/layout/activity_post_detail.xml
+++ b/Breaking/app/src/main/res/layout/activity_post_detail.xml
@@ -34,353 +34,379 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        tools:context=".board.PostDetailActivity">
-
-        <androidx.viewpager2.widget.ViewPager2
-            android:id="@+id/view_pager"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:orientation="horizontal"
-            app:layout_constraintDimensionRatio="1:1"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <ImageView
-            android:id="@+id/iv_post_detail_default"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:background="@drawable/ic_default_post_image"
-            android:visibility="gone"
-            app:layout_constraintHeight_percent="0.36"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <LinearLayout
-            android:id="@+id/layout_indicators"
-            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:gravity="center"
-            android:paddingBottom="8dp"
-            app:layout_constraintBottom_toBottomOf="@id/view_pager"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            tools:context=".board.PostDetailActivity">
 
-        <ImageView
-            android:id="@+id/iv_profile_writer"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="5dp"
-            android:adjustViewBounds="true"
-            android:scaleType="centerCrop"
-            app:layout_constraintBottom_toTopOf="@+id/divider1"
-            app:layout_constraintHorizontal_bias="0.048"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/view_pager"
-            app:layout_constraintVertical_bias="0.285"
-            app:layout_constraintWidth_percent="0.2"
-            tools:srcCompat="@tools:sample/avatars" />
+            <com.facebook.shimmer.ShimmerFrameLayout
+                android:id="@+id/sfl_post_detail_skeleton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_bias="0">
 
-        <TextView
-            android:id="@+id/tv_user_nick_name"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="5dp"
-            android:gravity="center"
-            android:text=""
-            android:textStyle="bold"
-            android:textColor="@color/black"
-            app:layout_constraintLeft_toLeftOf="@+id/iv_profile_writer"
-            app:layout_constraintTop_toBottomOf="@+id/iv_profile_writer"
-            app:layout_constraintRight_toRightOf="@+id/iv_profile_writer"/>
+                <include layout="@layout/skeleton_item_post_detail" />
 
-        <TextView
-            android:id="@+id/tv_chip_exclusive"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@drawable/chip_post_exclusive_background"
-            android:gravity="center"
-            android:paddingStart="8dp"
-            android:paddingTop="2dp"
-            android:paddingEnd="8dp"
-            android:paddingBottom="2dp"
-            android:layout_marginEnd="6dp"
-            android:text="@string/exclusive_string"
-            android:textColor="@color/white"
-            android:textSize="10sp"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toTopOf="@+id/tv_title"
-            app:layout_constraintHorizontal_bias="0"
-            app:layout_constraintVertical_bias="0"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintLeft_toLeftOf="@id/tv_title"
-            app:layout_constraintRight_toLeftOf="@id/tv_chip_sold"
-            app:layout_constraintTop_toTopOf="@id/iv_profile_writer" />
+            </com.facebook.shimmer.ShimmerFrameLayout>
 
-        <TextView
-            android:id="@+id/tv_chip_sold"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@drawable/chip_post_sold_background"
-            android:layout_marginEnd="6dp"
-            android:gravity="center"
-            android:paddingStart="8dp"
-            android:paddingTop="2dp"
-            android:paddingEnd="8dp"
-            android:paddingBottom="2dp"
-            android:text="@string/sold_string"
-            android:textColor="@color/white"
-            android:textSize="10sp"
-            android:textStyle="bold"
-            app:layout_constraintHorizontal_bias="1"
-            app:layout_constraintLeft_toRightOf="@id/tv_chip_exclusive"
-            app:layout_constraintRight_toLeftOf="@id/tv_chip_unsold"
-            app:layout_constraintTop_toTopOf="@id/iv_profile_writer" />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/view_whole_content_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:translationZ="10dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
-            android:id="@+id/tv_chip_unsold"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@drawable/chip_post_unsold_background"
-            android:gravity="center"
-            android:paddingStart="8dp"
-            android:paddingTop="2dp"
-            android:paddingEnd="8dp"
-            android:paddingBottom="2dp"
-            android:text="@string/is_selling_string"
-            android:textColor="@color/breaking_color"
-            android:textSize="10sp"
-            android:textStyle="bold"
-            app:layout_constraintHorizontal_bias="0"
-            app:layout_constraintLeft_toRightOf="@id/tv_chip_sold"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="@id/iv_profile_writer" />
+                <androidx.viewpager2.widget.ViewPager2
+                    android:id="@+id/view_pager"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:orientation="horizontal"
+                    app:layout_constraintDimensionRatio="1:1"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-        <View
-            android:id="@+id/divider_post_type"
-            android:layout_width="0dp"
-            android:layout_height="0.1dp"
-            android:backgroundTint="@color/white"
-            app:layout_constraintVertical_bias="0"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintLeft_toLeftOf="@id/tv_title"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="@id/tv_chip_exclusive"
-            app:layout_constraintBottom_toTopOf="@+id/tv_title"/>
+                <ImageView
+                    android:id="@+id/iv_post_detail_default"
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp"
+                    android:background="@drawable/ic_default_post_image"
+                    android:visibility="gone"
+                    app:layout_constraintHeight_percent="0.36"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/tv_title"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
-            android:layout_marginTop="25dp"
-            android:ellipsize="end"
-            android:text=""
-            android:textColor="@color/black"
-            android:textSize="17sp"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintLeft_toRightOf="@+id/iv_profile_writer"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/divider_post_type" />
+                <LinearLayout
+                    android:id="@+id/layout_indicators"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center"
+                    android:paddingBottom="8dp"
+                    app:layout_constraintBottom_toBottomOf="@id/view_pager"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
 
-        <ImageView
-            android:id="@+id/iv_location_icon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="5dp"
-            android:background="@drawable/ic_baseline_location_on_24"
-            app:layout_constraintLeft_toLeftOf="@id/tv_title"
-            app:layout_constraintTop_toBottomOf="@+id/tv_title"
-            app:layout_constraintWidth_percent="0.045" />
+                <ImageView
+                    android:id="@+id/iv_profile_writer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="5dp"
+                    android:adjustViewBounds="true"
+                    android:scaleType="centerCrop"
+                    app:layout_constraintBottom_toTopOf="@+id/divider1"
+                    app:layout_constraintHorizontal_bias="0.048"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/view_pager"
+                    app:layout_constraintVertical_bias="0.285"
+                    app:layout_constraintWidth_percent="0.18"
+                    tools:srcCompat="@tools:sample/avatars" />
 
-        <TextView
-            android:id="@+id/tv_post_location"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="5dp"
-            android:text=""
-            android:textColor="@color/breaking_color"
-            android:textSize="12sp"
-            app:layout_constraintTop_toTopOf="@id/iv_location_icon"
-            app:layout_constraintBottom_toBottomOf="@id/iv_location_icon"
-            app:layout_constraintLeft_toRightOf="@id/iv_location_icon" />
-        <TextView
-            android:id="@+id/tv_post_time"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:ellipsize="end"
-            android:text=""
-            android:textSize="12sp"
-            android:layout_marginTop="5dp"
-            app:layout_constraintVertical_bias="0"
-            app:layout_constraintBottom_toTopOf="@+id/divider1"
-            app:layout_constraintLeft_toLeftOf="@+id/iv_location_icon"
-            app:layout_constraintTop_toBottomOf="@+id/iv_location_icon" />
+                <TextView
+                    android:id="@+id/tv_user_nick_name"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="5dp"
+                    android:gravity="center"
+                    android:text=""
+                    android:textSize="12sp"
+                    android:textStyle="bold"
+                    android:textColor="@color/black"
+                    app:layout_constraintLeft_toLeftOf="@+id/iv_profile_writer"
+                    app:layout_constraintTop_toBottomOf="@+id/iv_profile_writer"
+                    app:layout_constraintRight_toRightOf="@+id/iv_profile_writer"/>
 
-        <Button
-            android:id="@+id/btn_purchase"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginBottom="5dp"
-            app:layout_constraintWidth_percent="0.22"
-            app:layout_constraintHeight_percent="0.04"
-            android:background="@drawable/sign_up_user_type_selected"
-            android:text="@string/post_detail_btn_purchase"
-            app:layout_constraintHorizontal_bias="0.9"
-            app:layout_constraintVertical_bias="1"
-            app:layout_constraintTop_toBottomOf="@id/tv_post_price"
-            app:layout_constraintBottom_toTopOf="@id/divider1"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            />
+                <TextView
+                    android:id="@+id/tv_chip_exclusive"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/chip_post_exclusive_background"
+                    android:gravity="center"
+                    android:paddingStart="8dp"
+                    android:paddingTop="2dp"
+                    android:paddingEnd="8dp"
+                    android:paddingBottom="2dp"
+                    android:layout_marginEnd="6dp"
+                    android:text="@string/exclusive_string"
+                    android:textColor="@color/white"
+                    android:textSize="10sp"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toTopOf="@+id/tv_title"
+                    app:layout_constraintHorizontal_bias="0"
+                    app:layout_constraintVertical_bias="0"
+                    app:layout_constraintHorizontal_chainStyle="packed"
+                    app:layout_constraintLeft_toLeftOf="@id/tv_title"
+                    app:layout_constraintRight_toLeftOf="@id/tv_chip_sold"
+                    app:layout_constraintTop_toTopOf="@id/iv_profile_writer" />
 
-        <TextView
-            android:id="@+id/tv_post_price"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:layout_constraintWidth_percent="0.3"
-            android:gravity="center"
-            android:layout_marginTop="5dp"
-            android:layout_marginBottom="5dp"
-            android:text=""
-            android:textColor="@color/black"
-            android:textStyle="bold"
-            android:textSize="14sp"
-            app:layout_constraintTop_toBottomOf="@+id/tv_title"
-            app:layout_constraintLeft_toLeftOf="@+id/btn_purchase"
-            app:layout_constraintBottom_toTopOf="@+id/btn_purchase"
-            app:layout_constraintRight_toRightOf="@+id/btn_purchase"/>
+                <TextView
+                    android:id="@+id/tv_chip_sold"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/chip_post_sold_background"
+                    android:layout_marginEnd="6dp"
+                    android:gravity="center"
+                    android:paddingStart="8dp"
+                    android:paddingTop="2dp"
+                    android:paddingEnd="8dp"
+                    android:paddingBottom="2dp"
+                    android:text="@string/sold_string"
+                    android:textColor="@color/white"
+                    android:textSize="10sp"
+                    android:textStyle="bold"
+                    app:layout_constraintHorizontal_bias="1"
+                    app:layout_constraintLeft_toRightOf="@id/tv_chip_exclusive"
+                    app:layout_constraintRight_toLeftOf="@id/tv_chip_unsold"
+                    app:layout_constraintTop_toTopOf="@id/iv_profile_writer" />
 
-        <View
-            android:id="@+id/divider1"
-            android:layout_width="0dp"
-            android:layout_height="1dp"
-            android:layout_marginTop="20dp"
-            android:background="@color/gray"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_post_time" />
+                <TextView
+                    android:id="@+id/tv_chip_unsold"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/chip_post_unsold_background"
+                    android:gravity="center"
+                    android:paddingStart="8dp"
+                    android:paddingTop="2dp"
+                    android:paddingEnd="8dp"
+                    android:paddingBottom="2dp"
+                    android:text="@string/is_selling_string"
+                    android:textColor="@color/breaking_color"
+                    android:textSize="10sp"
+                    android:textStyle="bold"
+                    app:layout_constraintHorizontal_bias="0"
+                    app:layout_constraintLeft_toRightOf="@id/tv_chip_sold"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/iv_profile_writer" />
 
-        <TextView
-            android:id="@+id/tv_post_content"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:textColor="?android:attr/textColorPrimary"
-            android:textSize="15sp"
-            android:layout_marginTop="7dp"
-            android:padding="10dp"
-            android:ellipsize="end"
-            android:text=""
-            android:lines="10"
-            android:scrollbars="vertical"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/divider1" />
+                <View
+                    android:id="@+id/divider_post_type"
+                    android:layout_width="0dp"
+                    android:layout_height="0.1dp"
+                    android:backgroundTint="@color/white"
+                    app:layout_constraintVertical_bias="0"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintLeft_toLeftOf="@id/tv_title"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/tv_chip_exclusive"
+                    app:layout_constraintBottom_toTopOf="@+id/tv_title"/>
 
-        <ImageButton
-            android:id="@+id/ib_post_like"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            android:background="@drawable/ic_post_like"
-            app:layout_constraintLeft_toLeftOf="@+id/tv_user_nick_name"
-            app:layout_constraintTop_toBottomOf="@+id/tv_post_content" />
+                <TextView
+                    android:id="@+id/tv_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="10dp"
+                    android:layout_marginTop="25dp"
+                    android:ellipsize="end"
+                    android:text=""
+                    android:textColor="@color/black"
+                    android:textSize="17sp"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintLeft_toRightOf="@+id/iv_profile_writer"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/divider_post_type" />
 
-        <ImageButton
-            android:id="@+id/ib_post_comment"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@drawable/ic_post_comment"
-            app:layout_constraintHorizontal_bias="0.05"
-            app:layout_constraintTop_toTopOf="@+id/ib_post_like"
-            app:layout_constraintBottom_toBottomOf="@+id/ib_post_like"
-            app:layout_constraintLeft_toRightOf="@id/ib_post_like"
-            app:layout_constraintRight_toRightOf="parent"
-            tools:layout_editor_absoluteY="356dp" />
+                <ImageView
+                    android:id="@+id/iv_location_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="5dp"
+                    android:background="@drawable/ic_baseline_location_on_24"
+                    app:layout_constraintLeft_toLeftOf="@id/tv_title"
+                    app:layout_constraintTop_toBottomOf="@+id/tv_title"
+                    app:layout_constraintWidth_percent="0.045" />
 
-        <ImageButton
-            android:id="@+id/ib_post_more"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@drawable/ic_baseline_more_horiz_24"
-            app:layout_constraintHorizontal_bias="0.92"
-            app:layout_constraintTop_toTopOf="@+id/ib_post_like"
-            app:layout_constraintBottom_toBottomOf="@+id/ib_post_like"
-            app:layout_constraintLeft_toRightOf="@id/ib_post_comment"
-            app:layout_constraintRight_toRightOf="parent" />
+                <TextView
+                    android:id="@+id/tv_post_location"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="5dp"
+                    android:text=""
+                    android:textColor="@color/breaking_color"
+                    android:textSize="12sp"
+                    app:layout_constraintTop_toTopOf="@id/iv_location_icon"
+                    app:layout_constraintBottom_toBottomOf="@id/iv_location_icon"
+                    app:layout_constraintLeft_toRightOf="@id/iv_location_icon" />
+                <TextView
+                    android:id="@+id/tv_post_time"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:text=""
+                    android:textSize="11sp"
+                    android:layout_marginTop="5dp"
+                    app:layout_constraintVertical_bias="0"
+                    app:layout_constraintBottom_toTopOf="@+id/divider1"
+                    app:layout_constraintLeft_toLeftOf="@+id/iv_location_icon"
+                    app:layout_constraintTop_toBottomOf="@+id/iv_location_icon" />
 
-        <View
-            android:id="@+id/divider2"
-            android:layout_width="0dp"
-            android:layout_height="1dp"
-            android:layout_marginTop="10dp"
-            android:background="@color/gray"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/ib_post_like" />
+                <Button
+                    android:id="@+id/btn_purchase"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:layout_marginBottom="5dp"
+                    app:layout_constraintWidth_percent="0.2"
+                    app:layout_constraintHeight_percent="0.04"
+                    android:background="@drawable/sign_up_user_type_selected"
+                    android:text="@string/post_detail_btn_purchase"
+                    android:textSize="12sp"
+                    app:layout_constraintHorizontal_bias="0.93"
+                    app:layout_constraintVertical_bias="1"
+                    app:layout_constraintTop_toBottomOf="@id/tv_post_price"
+                    app:layout_constraintBottom_toTopOf="@id/divider1"
+                    app:layout_constraintLeft_toRightOf="@id/tv_post_time"
+                    app:layout_constraintRight_toRightOf="parent"
+                    />
 
-        <ImageView
-            android:id="@+id/iv_comment_writer_profile"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
-            android:adjustViewBounds="true"
-            android:scaleType="centerCrop"
-            app:layout_constraintBottom_toTopOf="@+id/rv_comment_list"
-            app:layout_constraintLeft_toLeftOf="@+id/ib_post_like"
-            app:layout_constraintTop_toBottomOf="@+id/divider2"
-            app:layout_constraintWidth_percent="0.17"
-            tools:srcCompat="@tools:sample/avatars" />
+                <TextView
+                    android:id="@+id/tv_post_price"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintWidth_percent="0.3"
+                    android:gravity="center"
+                    android:layout_marginTop="5dp"
+                    android:layout_marginBottom="5dp"
+                    android:text=""
+                    android:textColor="@color/black"
+                    android:textStyle="bold"
+                    android:textSize="12sp"
+                    app:layout_constraintTop_toBottomOf="@+id/tv_title"
+                    app:layout_constraintLeft_toLeftOf="@+id/btn_purchase"
+                    app:layout_constraintBottom_toTopOf="@+id/btn_purchase"
+                    app:layout_constraintRight_toRightOf="@+id/btn_purchase"/>
 
-        <EditText
-            android:id="@+id/et_post_write"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
-            android:hint="@string/post_detail_add_comment_hint"
-            android:lines="3"
-            android:background="@null"
-            android:scrollbars="vertical"
-            android:maxLength="1000"
-            app:layout_constraintHorizontal_bias="0.1"
-            app:layout_constraintLeft_toRightOf="@+id/iv_comment_writer_profile"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/divider2"
-            app:layout_constraintBottom_toBottomOf="@+id/iv_comment_writer_profile"
-            app:layout_constraintWidth_percent="0.65" />
+                <View
+                    android:id="@+id/divider1"
+                    android:layout_width="0dp"
+                    android:layout_height="1dp"
+                    android:layout_marginTop="20dp"
+                    android:background="@color/gray"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_post_time" />
 
-        <TextView
-            android:id="@+id/tv_add_comment"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/post_detail_add_comment"
-            android:textColor="@color/breaking_color"
-            android:textSize="16sp"
-            app:layout_constraintHorizontal_bias="0"
-            app:layout_constraintTop_toTopOf="@+id/et_post_write"
-            app:layout_constraintBottom_toBottomOf="@+id/et_post_write"
-            app:layout_constraintLeft_toRightOf="@+id/et_post_write"
-            app:layout_constraintRight_toRightOf="parent"
-             />
+                <TextView
+                    android:id="@+id/tv_post_content"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="15sp"
+                    android:layout_marginTop="7dp"
+                    android:padding="10dp"
+                    android:ellipsize="end"
+                    android:text=""
+                    android:lines="10"
+                    android:scrollbars="vertical"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/divider1" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_comment_list"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            android:orientation="vertical"
-            app:layout_constraintLeft_toLeftOf="@+id/iv_comment_writer_profile"
-            app:layout_constraintRight_toRightOf="@id/et_post_write"
-            app:layout_constraintTop_toBottomOf="@+id/iv_comment_writer_profile"
-            />
+                <ImageButton
+                    android:id="@+id/ib_post_like"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:background="@drawable/ic_post_like"
+                    app:layout_constraintLeft_toLeftOf="@+id/tv_user_nick_name"
+                    app:layout_constraintTop_toBottomOf="@+id/tv_post_content" />
+
+                <ImageButton
+                    android:id="@+id/ib_post_comment"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/ic_post_comment"
+                    app:layout_constraintHorizontal_bias="0.05"
+                    app:layout_constraintTop_toTopOf="@+id/ib_post_like"
+                    app:layout_constraintBottom_toBottomOf="@+id/ib_post_like"
+                    app:layout_constraintLeft_toRightOf="@id/ib_post_like"
+                    app:layout_constraintRight_toRightOf="parent"
+                    tools:layout_editor_absoluteY="356dp" />
+
+                <ImageButton
+                    android:id="@+id/ib_post_more"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/ic_baseline_more_horiz_24"
+                    app:layout_constraintHorizontal_bias="0.92"
+                    app:layout_constraintTop_toTopOf="@+id/ib_post_like"
+                    app:layout_constraintBottom_toBottomOf="@+id/ib_post_like"
+                    app:layout_constraintLeft_toRightOf="@id/ib_post_comment"
+                    app:layout_constraintRight_toRightOf="parent" />
+
+                <View
+                    android:id="@+id/divider2"
+                    android:layout_width="0dp"
+                    android:layout_height="1dp"
+                    android:layout_marginTop="10dp"
+                    android:background="@color/gray"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/ib_post_like" />
+
+                <ImageView
+                    android:id="@+id/iv_comment_writer_profile"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:adjustViewBounds="true"
+                    android:scaleType="centerCrop"
+                    app:layout_constraintBottom_toTopOf="@+id/rv_comment_list"
+                    app:layout_constraintLeft_toLeftOf="@+id/ib_post_like"
+                    app:layout_constraintRight_toRightOf="@+id/iv_profile_writer"
+                    app:layout_constraintTop_toBottomOf="@+id/divider2"
+                    app:layout_constraintWidth_percent="0.15"
+                    tools:srcCompat="@tools:sample/avatars" />
+
+                <EditText
+                    android:id="@+id/et_post_write"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:hint="@string/post_detail_add_comment_hint"
+                    android:textSize="15sp"
+                    android:lines="3"
+                    android:background="@null"
+                    android:scrollbars="vertical"
+                    android:maxLength="1000"
+                    app:layout_constraintHorizontal_bias="0"
+                    app:layout_constraintLeft_toLeftOf="@+id/tv_title"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/divider2"
+                    app:layout_constraintBottom_toBottomOf="@+id/iv_comment_writer_profile"
+                    app:layout_constraintWidth_percent="0.63" />
+
+                <TextView
+                    android:id="@+id/tv_add_comment"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/post_detail_add_comment"
+                    android:textColor="@color/breaking_color"
+                    android:textSize="15sp"
+                    app:layout_constraintHorizontal_bias="0"
+                    app:layout_constraintTop_toTopOf="@+id/et_post_write"
+                    app:layout_constraintBottom_toBottomOf="@+id/et_post_write"
+                    app:layout_constraintLeft_toRightOf="@+id/et_post_write"
+                    app:layout_constraintRight_toRightOf="parent"
+                     />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rv_comment_list"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:orientation="vertical"
+                    app:layout_constraintLeft_toLeftOf="@+id/iv_comment_writer_profile"
+                    app:layout_constraintRight_toRightOf="@id/et_post_write"
+                    app:layout_constraintTop_toBottomOf="@+id/iv_comment_writer_profile"
+                    />
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.core.widget.NestedScrollView>

--- a/Breaking/app/src/main/res/layout/skeleton_item_post_detail.xml
+++ b/Breaking/app/src/main/res/layout/skeleton_item_post_detail.xml
@@ -1,0 +1,280 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/test_view"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/iv_post_detail_default_test"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:background="@drawable/ic_default_post_image"
+        android:visibility="visible"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintHeight_percent="0.36"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/iv_profile_writer_test"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="5dp"
+        android:adjustViewBounds="true"
+        android:scaleType="centerCrop"
+        android:background="@drawable/skeleton_circle_background"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintBottom_toTopOf="@+id/divider1_test"
+        app:layout_constraintHorizontal_bias="0.048"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/iv_post_detail_default_test"
+        app:layout_constraintVertical_bias="0.285"
+        app:layout_constraintWidth_percent="0.18" />
+
+    <TextView
+        android:id="@+id/tv_user_nick_name_test"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:gravity="center"
+        android:text=""
+        android:textStyle="bold"
+        android:textColor="@color/black"
+        android:background="@drawable/skeleton_background"
+        app:layout_constraintLeft_toLeftOf="@+id/iv_profile_writer_test"
+        app:layout_constraintTop_toBottomOf="@+id/iv_profile_writer_test"
+        app:layout_constraintRight_toRightOf="@+id/iv_profile_writer_test"/>
+
+    <TextView
+        android:id="@+id/tv_chip_test"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="10dp"
+        android:background="@drawable/skeleton_background"
+        android:ellipsize="end"
+        android:text=""
+        android:textColor="@color/black"
+        android:textSize="17sp"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintLeft_toRightOf="@+id/iv_profile_writer_test"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/iv_profile_writer_test"
+        app:layout_constraintWidth_percent="0.4" />
+
+    <TextView
+        android:id="@+id/tv_title_test"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="10dp"
+        android:layout_marginTop="7dp"
+        android:layout_marginRight="10dp"
+        android:ellipsize="end"
+        android:text=""
+        android:textColor="@color/black"
+        android:textSize="17sp"
+        android:background="@drawable/skeleton_background"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintLeft_toRightOf="@+id/iv_profile_writer_test"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tv_chip_test" />
+
+    <ImageView
+        android:id="@+id/iv_location_icon_test"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="5dp"
+        android:background="@drawable/skeleton_background"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintLeft_toLeftOf="@id/tv_title_test"
+        app:layout_constraintTop_toBottomOf="@+id/tv_title_test"
+        app:layout_constraintWidth_percent="0.045" />
+
+    <TextView
+        android:id="@+id/tv_post_location_test"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="5dp"
+        android:text=""
+        android:textColor="@color/breaking_color"
+        android:textSize="12sp"
+        android:background="@drawable/skeleton_background"
+        app:layout_constraintWidth_percent="0.35"
+        app:layout_constraintTop_toTopOf="@id/iv_location_icon_test"
+        app:layout_constraintBottom_toBottomOf="@id/iv_location_icon_test"
+        app:layout_constraintLeft_toRightOf="@id/iv_location_icon_test" />
+    <TextView
+        android:id="@+id/tv_post_time_test"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintWidth_percent="0.41"
+        android:ellipsize="end"
+        android:text=""
+        android:textSize="12sp"
+        android:layout_marginTop="5dp"
+        android:background="@drawable/skeleton_background"
+        app:layout_constraintVertical_bias="0"
+        app:layout_constraintBottom_toTopOf="@+id/divider1_test"
+        app:layout_constraintLeft_toLeftOf="@+id/iv_location_icon_test"
+        app:layout_constraintTop_toBottomOf="@+id/iv_location_icon_test" />
+
+    <Button
+        android:id="@+id/btn_purchase_test"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginBottom="5dp"
+        app:layout_constraintWidth_percent="0.22"
+        app:layout_constraintHeight_percent="0.04"
+        android:background="@drawable/sign_up_user_type_selected"
+        android:text="@string/post_detail_btn_purchase"
+        android:visibility="invisible"
+        app:layout_constraintHorizontal_bias="0.9"
+        app:layout_constraintVertical_bias="1"
+        app:layout_constraintTop_toBottomOf="@id/tv_post_price_test"
+        app:layout_constraintBottom_toTopOf="@id/divider1_test"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        />
+
+    <TextView
+        android:id="@+id/tv_post_price_test"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintWidth_percent="0.3"
+        android:gravity="center"
+        android:layout_marginTop="5dp"
+        android:layout_marginBottom="5dp"
+        android:text=""
+        android:textColor="@color/black"
+        android:textStyle="bold"
+        android:textSize="14sp"
+        android:background="@drawable/skeleton_background"
+        app:layout_constraintTop_toBottomOf="@+id/tv_title_test"
+        app:layout_constraintLeft_toLeftOf="@+id/btn_purchase_test"
+        app:layout_constraintBottom_toTopOf="@+id/btn_purchase_test"
+        app:layout_constraintRight_toRightOf="@+id/btn_purchase_test"/>
+
+    <View
+        android:id="@+id/divider1_test"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_marginTop="20dp"
+        android:background="@color/gray"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_post_time_test" />
+
+    <TextView
+        android:id="@+id/tv_post_content_test"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textSize="15sp"
+        android:layout_marginTop="7dp"
+        android:padding="10dp"
+        android:ellipsize="end"
+        android:text=""
+        android:lines="10"
+        android:scrollbars="vertical"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/divider1_test" />
+
+    <ImageButton
+        android:id="@+id/ib_post_like_test"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:background="@drawable/ic_post_like"
+        android:visibility="invisible"
+        app:layout_constraintLeft_toLeftOf="@+id/tv_user_nick_name_test"
+        app:layout_constraintTop_toBottomOf="@+id/tv_post_content_test" />
+
+    <ImageButton
+        android:id="@+id/ib_post_comment_test"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/ic_post_comment"
+        android:visibility="invisible"
+        app:layout_constraintHorizontal_bias="0.05"
+        app:layout_constraintTop_toTopOf="@+id/ib_post_like_test"
+        app:layout_constraintBottom_toBottomOf="@+id/ib_post_like_test"
+        app:layout_constraintLeft_toRightOf="@id/ib_post_like_test"
+        app:layout_constraintRight_toRightOf="parent"
+        tools:layout_editor_absoluteY="356dp" />
+
+    <ImageButton
+        android:id="@+id/ib_post_more_test"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/ic_baseline_more_horiz_24"
+        android:visibility="invisible"
+        app:layout_constraintHorizontal_bias="0.92"
+        app:layout_constraintTop_toTopOf="@+id/ib_post_like_test"
+        app:layout_constraintBottom_toBottomOf="@+id/ib_post_like_test"
+        app:layout_constraintLeft_toRightOf="@id/ib_post_comment_test"
+        app:layout_constraintRight_toRightOf="parent" />
+
+    <View
+        android:id="@+id/divider2_test"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_marginTop="10dp"
+        android:background="@color/gray"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/ib_post_like_test" />
+
+    <ImageView
+        android:id="@+id/iv_comment_writer_profile_test"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="20dp"
+        android:adjustViewBounds="true"
+        android:scaleType="centerCrop"
+        android:background="@drawable/skeleton_circle_background"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="@+id/ib_post_like_test"
+        app:layout_constraintRight_toRightOf="@+id/iv_profile_writer_test"
+        app:layout_constraintTop_toBottomOf="@+id/divider2_test"
+        app:layout_constraintWidth_percent="0.15" />
+
+    <EditText
+        android:id="@+id/et_post_write_test"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="20dp"
+        android:lines="3"
+        android:background="@drawable/skeleton_background"
+        android:scrollbars="vertical"
+        android:maxLength="1000"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintLeft_toLeftOf="@+id/tv_title_test"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/divider2_test"
+        app:layout_constraintBottom_toBottomOf="@+id/iv_comment_writer_profile_test"
+        app:layout_constraintWidth_percent="0.63"
+        app:layout_constraintHeight_percent="0.06"/>
+
+    <TextView
+        android:id="@+id/tv_add_comment_test"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/post_detail_add_comment"
+        android:textColor="@color/breaking_color"
+        android:textSize="16sp"
+        android:visibility="invisible"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintTop_toTopOf="@+id/et_post_write_test"
+        app:layout_constraintBottom_toBottomOf="@+id/et_post_write_test"
+        app:layout_constraintLeft_toRightOf="@+id/et_post_write_test"
+        app:layout_constraintRight_toRightOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #99

## 예상 리뷰 시간
2-min

## 추가 또는 변경사항
- 게시글 세부 조회에서 스켈레톤 UI를 구현하였습니다.
- Spannable 에러와 사진이 안 보이던 문제는 안드로이드 쪽 문제가 아닌 것으로 확인되었습니다. (서버에서 데이터를 지운 것으로 추정)
- viewPager2 indicator 색상을 브레이킹 색상으로 변경하였습니다.
- 게시글 세부 조회에서 구매하기 버튼과 날짜가 겹치는 문제를 수정하였습니다.
- 게시글 세부 조회의 텍스트 크기, 프로필 이미지 크기를 전반적으로 수정하였습니다.
- 내가 작성한 제보/ 장바구니/ 북마크 페이지에서도 피드 리스트 클릭 이벤트를 정의하였습니다.

## 스크린샷
- 스켈레톤 UI
<img src="https://user-images.githubusercontent.com/31824443/187736822-71a9ad54-7419-4e72-a094-f071abdc8f0e.png" width="30%" height="30%"/>

- 게시글 세부 조회 (수정 버전)
<img src="https://user-images.githubusercontent.com/31824443/187736661-66908e5f-f080-4bba-b8b0-b79d96508b4b.png" width="30%" height="30%"/>


## 기타
- 스켈레톤 UI 삽질
  - @SeungGun 와 함께 약 4시간가량 삽질한 결과, view의 id가 스켈레톤 item View와 중복되어서 스켈레톤 뷰에 할당이 되어버리는 문제가 발생했던 것으로 보인다.. 정말 하나하나 경우의 수를 따져가며 디버깅 해본 것 같다..해결 되어서 다행이다 👍 
