### PR TITLE
feat: implement financial function (deposit, withdraw, transaction list)

### DIFF
--- a/Breaking/app/src/main/AndroidManifest.xml
+++ b/Breaking/app/src/main/AndroidManifest.xml
@@ -16,9 +16,13 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
+            android:name=".FinanceActivity"
+            android:exported="false"
+            android:windowSoftInputMode="adjustPan" />
+        <activity
             android:name=".FeedSearchActivity"
-            android:windowSoftInputMode="adjustPan"
-            android:exported="false" />
+            android:exported="false"
+            android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".board.PostDetailActivity"
             android:exported="false" />
@@ -105,13 +109,14 @@
                 android:resource="@xml/provider_paths" />
         </provider>
     </application>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
-
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
 </manifest>

--- a/Breaking/app/src/main/java/com/dope/breaking/FinanceActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/FinanceActivity.kt
@@ -1,0 +1,47 @@
+package com.dope.breaking
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import com.dope.breaking.adapter.FinanceViewPagerAdapter
+import com.dope.breaking.databinding.ActivityFinanceBinding
+import com.dope.breaking.model.response.ResponseExistLogin
+import com.dope.breaking.util.ValueUtil
+import com.google.android.material.tabs.TabLayoutMediator
+import java.text.DecimalFormat
+
+class FinanceActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityFinanceBinding
+    private val decimalFormat = DecimalFormat("#,###") // 숫자 포맷팅
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityFinanceBinding.inflate(layoutInflater)
+
+        initTabLayout() // 탭 설정
+
+        // 툴바 뒤로가기 버튼 클릭 시
+        binding.tbFinance.setNavigationOnClickListener {
+            finish()
+        }
+
+        // 현재 보유 금액 텍스트 보여주기
+        binding.tvAssessmentValue.text =
+            decimalFormat.format(ResponseExistLogin.baseUserInfo!!.balance) + "원"
+
+        setContentView(binding.root)
+    }
+
+    /**
+     * 탭 레이아웃 초기 설정 함수
+     * @author Seunggun Sin
+     * @since 2022-09-02
+     */
+    private fun initTabLayout() {
+        binding.vpFinance.adapter = FinanceViewPagerAdapter(
+            supportFragmentManager, lifecycle
+        )
+        TabLayoutMediator(binding.tlFinance, binding.vpFinance) { tab, position ->
+            tab.text = ValueUtil.FINANCE_TAB_TEXT[position]
+        }.attach()
+    }
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/SettingActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/SettingActivity.kt
@@ -13,15 +13,27 @@ import com.dope.breaking.util.ValueUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.text.DecimalFormat
 
 class SettingActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySettingBinding
+    private val decimalFormat = DecimalFormat("#,###")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivitySettingBinding.inflate(layoutInflater)
         binding.tbSetting.setNavigationIcon(R.drawable.ic_baseline_arrow_back_black_24)
+
+        // 보유 금액 값 보여주기
+        binding.tvFinanceValue.text =
+            "${decimalFormat.format(ResponseExistLogin.baseUserInfo!!.balance)}원"
+
         binding.tbSetting.setNavigationOnClickListener {
             finish()
+        }
+
+        // 보유한 금액 레이아웃 클릭 시
+        binding.clFinanceValue.setOnClickListener {
+            startActivity(Intent(this@SettingActivity, FinanceActivity::class.java))
         }
 
         // 로그아웃 클릭 시
@@ -62,5 +74,14 @@ class SettingActivity : AppCompatActivity() {
         intent.flags =
             Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
         startActivity(intent)
+    }
+
+    /**
+     * 보유 금액을 업데이트 하기 위한 생명주기 함수 충전, 출금 등으로 인한 계좌 값 반영
+     */
+    override fun onRestart() {
+        super.onRestart()
+        binding.tvFinanceValue.text =
+            "${decimalFormat.format(ResponseExistLogin.baseUserInfo!!.balance)}원"
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/adapter/FinanceViewPagerAdapter.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/adapter/FinanceViewPagerAdapter.kt
@@ -1,0 +1,29 @@
+package com.dope.breaking.adapter
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.Lifecycle
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.dope.breaking.fragment.finance_tab.TransactionListTabFragment
+import com.dope.breaking.fragment.finance_tab.ChargeTabFragment
+import com.dope.breaking.fragment.finance_tab.WithdrawTabFragment
+
+private const val NUM_TABS = 3
+
+class FinanceViewPagerAdapter(
+    fragmentManager: FragmentManager,
+    lifecycle: Lifecycle
+) : FragmentStateAdapter(fragmentManager, lifecycle) {
+    override fun getItemCount(): Int {
+        return NUM_TABS
+    }
+
+    override fun createFragment(position: Int): Fragment {
+        return when (position) {
+            0 -> ChargeTabFragment()
+            1 -> WithdrawTabFragment()
+            2 -> TransactionListTabFragment()
+            else -> ChargeTabFragment()
+        }
+    }
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/adapter/TransactionAdapter.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/adapter/TransactionAdapter.kt
@@ -1,0 +1,183 @@
+package com.dope.breaking.adapter
+
+import android.content.Context
+import android.graphics.Typeface
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.StyleSpan
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.dope.breaking.R
+import com.dope.breaking.model.response.ResponseMainFeed
+import com.dope.breaking.model.response.ResponseTransaction
+import com.dope.breaking.util.ValueUtil
+import java.text.DecimalFormat
+
+class TransactionAdapter(
+    private val context: Context,
+    val data: MutableList<ResponseTransaction?>
+) :
+    RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+    private val selfType = 0 // 충전/출금 레이아웃
+    private val otherType = 2 // 구매/판매 레이아웃
+    private val decimalFormat = DecimalFormat("#,###") // 숫자 포맷
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return when (viewType) {
+            selfType -> {
+                val view =
+                    LayoutInflater.from(context)
+                        .inflate(R.layout.item_transaction_self, parent, false)
+                SelfViewHolder(view)
+            }
+            otherType -> {
+                val view =
+                    LayoutInflater.from(context)
+                        .inflate(R.layout.item_transaction_other, parent, false)
+                OtherViewHolder(view)
+            }
+            else -> { // 로딩 레이아웃
+                val view =
+                    LayoutInflater.from(context).inflate(R.layout.item_loading, parent, false)
+                LoadingViewHolder(view)
+            }
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        if (holder is SelfViewHolder) {
+            holder.bind(data[position]!!)
+        } else if (holder is OtherViewHolder) {
+            holder.bind(data[position]!!)
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return data.size
+    }
+
+    /**
+     * View 타입
+     * 1. 데이터가 null 이면 로딩 아이템
+     * 2. 데이터의 거래 타입이 출금/입금 이면 self 아이템
+     * 3. 데이터의 거래 타입이 구매/판매 이면 other 아이템
+     */
+    override fun getItemViewType(position: Int): Int {
+        return if (data[position] == null) ValueUtil.VIEW_TYPE_LOADING
+        else
+            if (data[position]!!.transactionType == "withdraw"
+                || data[position]!!.transactionType == "deposit"
+            ) selfType
+            else otherType
+    }
+
+    inner class SelfViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        private val method = itemView.findViewById<TextView>(R.id.tv_self_transaction_method)
+        private val date = itemView.findViewById<TextView>(R.id.tv_self_transaction_date)
+        private val variable = itemView.findViewById<TextView>(R.id.tv_self_transaction_var)
+        private val balance = itemView.findViewById<TextView>(R.id.tv_self_transaction_balance)
+
+        fun bind(item: ResponseTransaction) {
+            date.text = item.transactionDate.replace("T", " ").split(".")[0]
+            balance.text = decimalFormat.format(item.balance) + "원"
+            if (item.transactionType == "withdraw") {
+                method.text = "출금"
+                method.setTextColor(context.getColor(R.color.sign_up_input_error_text_color))
+                variable.text = "-${decimalFormat.format(item.amount)}원"
+                variable.setTextColor(context.getColor(R.color.sign_up_input_error_text_color))
+            } else {
+                method.text = "입금"
+                method.setTextColor(context.getColor(R.color.breaking_color))
+
+                variable.text = "+${decimalFormat.format(item.amount)}원"
+                variable.setTextColor(context.getColor(R.color.breaking_color))
+            }
+
+        }
+    }
+
+    inner class OtherViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        private val method = itemView.findViewById<TextView>(R.id.tv_other_transaction_method)
+        private val title = itemView.findViewById<TextView>(R.id.tv_other_transaction_title)
+        private val date = itemView.findViewById<TextView>(R.id.tv_other_transaction_date)
+        private val variable = itemView.findViewById<TextView>(R.id.tv_other_transaction_var)
+        private val balance = itemView.findViewById<TextView>(R.id.tv_other_transaction_balance)
+
+        fun bind(item: ResponseTransaction) {
+            date.text = item.transactionDate.replace("T", " ").split(".")[0]
+            balance.text = decimalFormat.format(item.balance) + "원"
+            if (item.transactionType == "buy_post") {
+                method.text = "구매"
+                method.setTextColor(context.getColor(R.color.sign_up_input_error_text_color))
+                variable.text = "-${decimalFormat.format(item.amount)}원"
+                variable.setTextColor(context.getColor(R.color.sign_up_input_error_text_color))
+            } else {
+                method.text = "판매"
+                method.setTextColor(context.getColor(R.color.breaking_color))
+
+                variable.text = "+${decimalFormat.format(item.amount)}원"
+                variable.setTextColor(context.getColor(R.color.breaking_color))
+            }
+            val tmp =
+                if (item.transactionType == "buy_post") "${item.targetUser!!.nickname}님의 \'${item.postTitle}\' 구매"
+                else "${item.targetUser!!.nickname}님에게 \'${item.postTitle}\' 판매"
+
+            val spannableString = SpannableString(tmp)
+            val target1 = tmp.indexOf(item.targetUser.nickname)
+            val target2 = tmp.indexOf(item.postTitle!!)
+            spannableString.setSpan(
+                StyleSpan(Typeface.BOLD),
+                target1,
+                target1 + item.targetUser.nickname.length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+            spannableString.setSpan(
+                StyleSpan(Typeface.BOLD),
+                target2,
+                target2 + item.postTitle.length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+            title.text = spannableString
+        }
+    }
+
+    inner class LoadingViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        private val progressDialog = itemView.findViewById<ProgressBar>(R.id.progressbar_loading)
+    }
+
+    /**
+     * 아이템 리스트를 리스트에 추가하는 함수
+     * @param items(List<ResponseTransaction>): 입출금 내역 객체 리스트
+     * @author Seunggun Sin
+     * @since 2022-09-03
+     */
+    fun addItems(items: List<ResponseTransaction>) {
+        data.addAll(items)
+        notifyItemRangeInserted(itemCount, items.size)
+    }
+
+    /**
+     * 아이템 하나를 리스트에 추가하는 함수
+     * @param item(ResponseTransaction?): 입출금 아이템 객체 하나 (nullable)
+     * @author Seunggun Sin
+     * @since 2022-09-03
+     */
+    fun addItem(item: ResponseTransaction?) {
+        data.add(item)
+        notifyItemInserted(itemCount)
+    }
+
+    /**
+     * 리스트의 마지막 아이템을 지우는 함수
+     * @author Seunggun Sin
+     * @since 2022-09-03
+     */
+    fun removeLast() {
+        data.removeAt(data.size - 1)
+        notifyItemRemoved(data.size)
+    }
+
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/finance/FinanceManager.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/finance/FinanceManager.kt
@@ -1,0 +1,73 @@
+package com.dope.breaking.finance
+
+import com.dope.breaking.exception.ResponseErrorException
+import com.dope.breaking.model.request.RequestAmount
+import com.dope.breaking.model.response.ResponseTransaction
+import com.dope.breaking.retrofit.RetrofitManager
+import com.dope.breaking.retrofit.RetrofitService
+import kotlin.jvm.Throws
+
+class FinanceManager {
+
+    /**
+     * amount 만큼 입금을 요청하는 함수
+     * @param token(String): 본인의 Jwt 토큰 (필수)
+     * @param amount(Int): 입금하고자 하는 양
+     * @return Boolean: 입금의 성공 여부
+     * @author Seunggun Sin
+     * @since 2022-09-03
+     */
+    suspend fun startDepositRequest(
+        token: String,
+        amount: Int
+    ): Boolean {
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+
+        val response = service.requestDeposit(token, RequestAmount(amount))
+        return response.code() in 200..299
+    }
+
+    /**
+     * amount 만큼 출금을 요청하는 함수
+     * @param token(String): 본인의 Jwt 토큰 (필수)
+     * @param amount(Int): 출금하고자 하는 양
+     * @return Boolean: 출금의 성공 여부
+     * @author Seunggun Sin
+     * @since 2022-09-03
+     */
+    suspend fun startWithdrawRequest(
+        token: String,
+        amount: Int
+    ): Boolean {
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+
+        val response = service.requestWithdraw(token, RequestAmount(amount))
+        return response.code() in 200..299
+    }
+
+    /**
+     * 본인의 입출금 내역 리스트를 불러오는 요청
+     * @param token(String): 본인의 Jwt 토큰
+     * @param cursor(Int): 마지막으로 요청한 리스트의 마지막 인덱스
+     * @param size(Int): 가져올 아이템 개수
+     * @return List<ResponseTransaction>: 입출금 내역 리스트
+     * @throws ResponseErrorException: 응답 에러
+     * @author Seunggun Sin
+     * @since 2022-09-02
+     */
+    @Throws(ResponseErrorException::class)
+    suspend fun startGetFinanceList(
+        token: String,
+        cursor: Int,
+        size: Int
+    ): List<ResponseTransaction> {
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+
+        val response = service.requestTransactionList(token, cursor, size)
+
+        if (response.code() in 200..299)
+            return response.body()!!
+        else
+            throw ResponseErrorException("${response.errorBody()?.string()}")
+    }
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/finance_tab/ChargeTabFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/finance_tab/ChargeTabFragment.kt
@@ -1,0 +1,105 @@
+package com.dope.breaking.fragment.finance_tab
+
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import com.dope.breaking.databinding.FragmentFinanceChargeBinding
+import com.dope.breaking.finance.FinanceManager
+import com.dope.breaking.model.response.ResponseExistLogin
+import com.dope.breaking.util.DialogUtil
+import com.dope.breaking.util.JwtTokenUtil
+import com.dope.breaking.util.ValueUtil
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.text.DecimalFormat
+
+class ChargeTabFragment : Fragment() {
+    private lateinit var binding: FragmentFinanceChargeBinding
+    private val decimalFormat = DecimalFormat("#,###") // 숫자 포맷팅
+    private var inputPrice: String = "" // 마지막으로 입력한 숫자 문자열
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentFinanceChargeBinding.inflate(inflater, container, false)
+
+        // 충전하기 입력창 텍스트 감지
+        val textWatcher = object : TextWatcher {
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+                if (p0.toString().isNotEmpty() && p0.toString() != inputPrice) {
+                    inputPrice = decimalFormat.format(p0.toString().replace(",", "").toInt())
+                    binding.etInputCharge.setText(inputPrice)
+                    binding.etInputCharge.setSelection(inputPrice.length)
+                }
+            }
+
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+            }
+
+            override fun afterTextChanged(p0: Editable?) {
+            }
+        }
+        binding.etInputCharge.addTextChangedListener(textWatcher)
+
+        val token =
+            ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(requireContext()).getAccessTokenFromLocal()
+
+        // 충전하기 버튼 클릭 시 이벤트
+        binding.btnCharge.setOnClickListener {
+            // 입력한 값이 있다면
+            if (binding.etInputCharge.text.toString().isNotEmpty())
+            // 충전하기 재확인 dialog 실행
+                DialogUtil().MultipleDialog(
+                    requireContext(),
+                    "  정말로 ${inputPrice}원을 충전하시겠습니까?  ",
+                    "충전하기",
+                    "뒤로가기",
+                    leftEvent = {
+                        CoroutineScope(Dispatchers.Main).launch {
+                            val result = FinanceManager().startDepositRequest(
+                                token,
+                                getDecimalPrice(binding.etInputCharge.text.toString())
+                            ) // 입력한 값만큼 입금 요청
+
+                            if (result) { // 충전하기 성공 시
+                                ResponseExistLogin.baseUserInfo!!.balance += getDecimalPrice(binding.etInputCharge.text.toString()) // 유저 상태 정보의 계좌 업데이트
+                                showToast("충전이 완료되었습니다.")
+                                requireActivity().finish()
+                            } else // 충전하기 실패 시
+                                showToast("충전에 실패하였습니다.")
+                        }
+                    },
+                    allowCancel = true
+                ).show()
+        }
+        return binding.root
+    }
+
+    /**
+     * 포맷화된 숫자 문자열을 실제 숫자 값으로 반환하는 함수
+     * @param format(String): 포맷팅된 숫자 문자열
+     * @return Int: 변환한 실제 (Integer) 숫자
+     * @author Seunggun Sin
+     * @since 2022-09-02
+     */
+    private fun getDecimalPrice(format: String): Int {
+        return format.replace(",", "").toInt()
+    }
+
+    /**
+     * 토스트 메세지를 보여주는 함수
+     * @param message(String): 보여주고자 하는 문자열
+     * @author Seunggun Sin
+     * @since 2022-09-02
+     */
+    private fun showToast(message: String) {
+        Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/finance_tab/TransactionListTabFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/finance_tab/TransactionListTabFragment.kt
@@ -1,0 +1,134 @@
+package com.dope.breaking.fragment.finance_tab
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.dope.breaking.adapter.TransactionAdapter
+import com.dope.breaking.databinding.FragmentFinanceTransactionBinding
+import com.dope.breaking.exception.ResponseErrorException
+import com.dope.breaking.finance.FinanceManager
+import com.dope.breaking.model.response.ResponseTransaction
+import com.dope.breaking.util.JwtTokenUtil
+import com.dope.breaking.util.ValueUtil
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class TransactionListTabFragment : Fragment() {
+    private lateinit var binding: FragmentFinanceTransactionBinding
+    private val transactionList = mutableListOf<ResponseTransaction?>() // 거래 내역 리스트
+    private lateinit var adapter: TransactionAdapter // 거래 어댑터
+    private var isObtainedAll = false // 아이템을 다 받아왔는지 판단
+    private var isLoading = false // 로딩 중 판단
+    private val financeManager = FinanceManager() // 거래 매니저
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentFinanceTransactionBinding.inflate(inflater, container, false)
+
+        val token =
+            ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(requireContext()).getAccessTokenFromLocal()
+
+        /*
+            최초 입출금 내역 요청
+         */
+        processTransactionList(0, token, {
+            isLoading = true
+        }, { it ->
+            transactionList.addAll(it) // 받아온 아이템 리스트 리스트에 추가
+            adapter = TransactionAdapter(requireContext(), transactionList)
+
+            // 리스트가 비어있다면
+            if (it.isEmpty()) {
+                // 비어있는 텍스트 처리
+                binding.tvFinanceEmpty.visibility = View.VISIBLE
+                binding.rcvFinance.visibility = View.GONE
+            } else {
+                binding.tvFinanceEmpty.visibility = View.GONE
+                binding.rcvFinance.visibility = View.VISIBLE
+            }
+            // 어댑터 적용
+            binding.rcvFinance.adapter = adapter
+
+            // 로딩 종료
+            isLoading = false
+
+            // 스크롤 이벤트 리스너
+            binding.rcvFinance.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+                override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                    super.onScrollStateChanged(recyclerView, newState)
+                    // 마지막 아이템 인덱스
+                    val lastIndex =
+                        (recyclerView.layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition()
+
+                    // 가져온 아이템 사이즈가 가져와야하는 사이즈보다 작은 경우 새로운 요청을 못하게 막기
+                    if (recyclerView.adapter!!.itemCount < ValueUtil.TRANSACTION_SIZE) {
+                        return
+                    }
+
+                    if (lastIndex == recyclerView.adapter!!.itemCount - 1 && newState == 2 && !isObtainedAll && !isLoading) {
+                        processTransactionList(transactionList[lastIndex]!!.cursorId, token, {
+                            adapter.addItem(null) // 로딩 아이템 추가
+                            isLoading = true // 로딩 시작
+                        }, {
+                            // 가져와야하는 리스트보다 적은 경우
+                            if (it.size < ValueUtil.TRANSACTION_SIZE) {
+                                adapter.removeLast() // 로딩 아이템 제거
+                                if (it.isNotEmpty())
+                                    adapter.addItems(it) // 아이템 추가
+                                isObtainedAll = true // 모두 받아왔다는 flag 설정
+                            } else {
+                                adapter.removeLast() // 로딩 아이템 제거
+                                adapter.addItems(it) // 리스트 추가
+                            }
+                            isLoading = false // 로딩 종료
+                        }, {
+                            it.printStackTrace()
+                        })
+                    }
+                }
+            })
+        }, {
+            it.printStackTrace()
+        })
+
+        return binding.root
+    }
+
+    /**
+     * 입출금 내역을 요청하는 프로세스 함수
+     * @param cursorId(Int): 마지막으로 요청한 리스트의 마지막 인덱스
+     * @param token(String): 본인의 Jwt 토큰
+     * @param init(() -> Unit): 요청 전 초기 함수
+     * @param last((List<ResponseTransaction>) -> Unit): 요청 후처리 함수
+     * @param error((ResponseErrorException) -> Unit): 에러 함수
+     * @author Seunggun Sin
+     * @since 2022-09-03
+     */
+    private fun processTransactionList(
+        cursorId: Int,
+        token: String,
+        init: () -> Unit,
+        last: (List<ResponseTransaction>) -> Unit,
+        error: (ResponseErrorException) -> Unit
+    ) {
+        CoroutineScope(Dispatchers.Main).launch {
+            init()
+            try {
+                val responseList =
+                    financeManager.startGetFinanceList(token, cursorId, ValueUtil.TRANSACTION_SIZE)
+
+                last(responseList)
+            } catch (e: ResponseErrorException) {
+                error(e)
+            }
+        }
+    }
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/finance_tab/WithdrawTabFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/finance_tab/WithdrawTabFragment.kt
@@ -1,0 +1,106 @@
+package com.dope.breaking.fragment.finance_tab
+
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import com.dope.breaking.databinding.FragmentFinanceWithdrawBinding
+import com.dope.breaking.finance.FinanceManager
+import com.dope.breaking.model.response.ResponseExistLogin
+import com.dope.breaking.util.DialogUtil
+import com.dope.breaking.util.JwtTokenUtil
+import com.dope.breaking.util.ValueUtil
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.text.DecimalFormat
+
+class WithdrawTabFragment : Fragment() {
+    private lateinit var binding: FragmentFinanceWithdrawBinding
+    private val decimalFormat = DecimalFormat("#,###") // 숫자 포맷팅
+    private var inputPrice: String = "" // 마지막으로 입력한 숫자 문자열
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentFinanceWithdrawBinding.inflate(inflater, container, false)
+
+        // 출금하기 입력창 텍스트 감지
+        val textWatcher = object : TextWatcher {
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+                if (p0.toString().isNotEmpty() && p0.toString() != inputPrice) {
+                    inputPrice = decimalFormat.format(p0.toString().replace(",", "").toInt())
+                    binding.etInputWithdraw.setText(inputPrice)
+                    binding.etInputWithdraw.setSelection(inputPrice.length)
+                }
+            }
+
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+            }
+
+            override fun afterTextChanged(p0: Editable?) {
+            }
+        }
+        binding.etInputWithdraw.addTextChangedListener(textWatcher)
+
+        val token =
+            ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(requireContext()).getAccessTokenFromLocal()
+
+        // 출금하기 버튼 클릭 시 이벤트
+        binding.btnWithdraw.setOnClickListener {
+            // 입력한 값이 있다면
+            if (binding.etInputWithdraw.text.toString().isNotEmpty())
+            // 출금하기 재확인 dialog 실행
+                DialogUtil().MultipleDialog(
+                    requireContext(),
+                    "  정말로 ${inputPrice}원을 출금하시겠습니까?  ",
+                    "출금하기",
+                    "뒤로가기",
+                    leftEvent = {
+                        CoroutineScope(Dispatchers.Main).launch {
+                            val result = FinanceManager().startWithdrawRequest(
+                                token,
+                                getDecimalPrice(binding.etInputWithdraw.text.toString())
+                            ) // 입력한 값만큼 입금 요청
+
+                            if (result) {  // 충전하기 성공 시
+                                ResponseExistLogin.baseUserInfo!!.balance -= getDecimalPrice(binding.etInputWithdraw.text.toString()) // 유저 상태 정보의 계좌 업데이트
+                                showToast("출금이 완료되었습니다.")
+                                requireActivity().finish()
+                            } else // 충전하기 실패 시
+                                showToast("출금에 실패하였습니다.")
+
+                        }
+                    },
+                    allowCancel = true
+                ).show()
+        }
+        return binding.root
+    }
+
+    /**
+     * 포맷화된 숫자 문자열을 실제 숫자 값으로 반환하는 함수
+     * @param format(String): 포맷팅된 숫자 문자열
+     * @return Int: 변환한 실제 (Integer) 숫자
+     * @author Seunggun Sin
+     * @since 2022-09-02
+     */
+    private fun getDecimalPrice(format: String): Int {
+        return format.replace(",", "").toInt()
+    }
+
+    /**
+     * 토스트 메세지를 보여주는 함수
+     * @param message(String): 보여주고자 하는 문자열
+     * @author Seunggun Sin
+     * @since 2022-09-02
+     */
+    private fun showToast(message: String) {
+        Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/model/request/RequestAmount.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/request/RequestAmount.kt
@@ -1,0 +1,5 @@
+package com.dope.breaking.model.request
+
+data class RequestAmount(
+    val amount: Int
+)

--- a/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseExistLogin.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseExistLogin.kt
@@ -8,7 +8,7 @@ data class ResponseExistLogin(
     @SerializedName("userId") val userId: Long,
     @SerializedName("profileImgURL") val profileImgUrl: String?,
     @SerializedName("nickname") val nickname: String,
-    @SerializedName("balance") val balance: Int
+    @SerializedName("balance") var balance: Int
 ) : Serializable {
     companion object {
         var baseUserInfo: ResponseExistLogin? = null

--- a/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseTransaction.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseTransaction.kt
@@ -1,0 +1,14 @@
+package com.dope.breaking.model.response
+
+import com.google.gson.annotations.SerializedName
+
+data class ResponseTransaction(
+    @SerializedName("cursorId") val cursorId: Int,
+    @SerializedName("transactionDate") val transactionDate: String,
+    @SerializedName("transactionType") val transactionType: String,
+    @SerializedName("amount") val amount: Int,
+    @SerializedName("balance") val balance: Int,
+    @SerializedName("postId") val postId: Int?,
+    @SerializedName("postTitle") val postTitle: String?,
+    @SerializedName("targetUser") val targetUser: ResponseJwtUserInfo?
+)

--- a/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
@@ -1,6 +1,7 @@
 package com.dope.breaking.retrofit
 
 import com.dope.breaking.model.FollowData
+import com.dope.breaking.model.request.RequestAmount
 import com.dope.breaking.model.request.RequestGoogleAccessToken
 import com.dope.breaking.model.request.RequestGoogleToken
 import com.dope.breaking.model.request.RequestKakaoToken
@@ -254,6 +255,44 @@ interface RetrofitService {
         @Header("authorization") token: String,
         @Path("postId") postId: Int
     ): Response<Unit>
+
+    /**
+     * amount 양 만큼 입금하는 요청
+     * @header token(String): 본인의 Jwt 토큰 (필수)
+     * @body amount(RequestAmount): 입금하고자 하는 수량 (Int)
+     * @author Seunggun Sin
+     */
+    @POST("financial/deposit")
+    suspend fun requestDeposit(
+        @Header("authorization") token: String,
+        @Body amount: RequestAmount
+    ): Response<Unit>
+
+    /**
+     * amount 양 만큼 출금하는 요청
+     * @header token(String): 본인의 Jwt 토큰 (필수)
+     * @body amount(RequestAmount): 출금하고자 하는 수량 (Int)
+     * @author Seunggun Sin
+     */
+    @POST("financial/withdraw")
+    suspend fun requestWithdraw(
+        @Header("authorization") token: String,
+        @Body amount: RequestAmount
+    ): Response<Unit>
+
+    /**
+     * 입출금 내역 리스트를 가져오는 요청
+     * @header token(String): 본인의 Jwt 토큰 (필수)
+     * @query cursor(Int): 마지막으로 요청한 리스트에서 마지막 인덱스 커서
+     * @query size(Int): 리스트에서 가져올 개수
+     * @author Seunggun Sin
+     */
+    @GET("profile/transaction")
+    suspend fun requestTransactionList(
+        @Header("authorization") token: String,
+        @Query("cursor") cursorId: Int,
+        @Query("size") contentSize: Int
+    ): Response<List<ResponseTransaction>>
 
     /**
      * 유저의 고유 id 를 갖고 유저의 프로필 정보를 가져오는 요청 (회원가입이 되어있는 유저가 요청하는 경우)

--- a/Breaking/app/src/main/java/com/dope/breaking/util/ValueUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/ValueUtil.kt
@@ -23,12 +23,19 @@ class ValueUtil {
         const val VIEW_TYPE_ITEM = 0 // 일반 아이템에 대한 레이아웃 view type
         const val VIEW_TYPE_LOADING = 1 // 로딩 아이템에 대한 레이아웃 view type
         const val USER_FEED_SIZE = 6 // 유저 페이지 피드 요청마다 가져올 게시글 개수
+        const val TRANSACTION_SIZE = 20 // 입출금 내역 리스트 가져올 개수
 
         val TAB_ICONS = arrayOf(
             R.drawable.ic_baseline_create_24,
             R.drawable.ic_baseline_add_shopping_cart_24,
             R.drawable.ic_baseline_bookmark_border_24
         ) // 게시글 아이콘 리스트
+
+        val FINANCE_TAB_TEXT = arrayOf(
+            "충전하기",
+            "출금하기",
+            "입출금 내역"
+        )
 
         val FILTER_SELL_OPTIONS = arrayOf(
             "all",

--- a/Breaking/app/src/main/res/drawable/border_white_background.xml
+++ b/Breaking/app/src/main/res/drawable/border_white_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="6dip" />
+    <solid android:color="@color/white" />
+    <stroke
+        android:width="2dp"
+        android:color="@color/black" />
+</shape>

--- a/Breaking/app/src/main/res/drawable/finance_other_background.xml
+++ b/Breaking/app/src/main/res/drawable/finance_other_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="8dip" />
+    <solid android:color="@color/white" />
+    <stroke
+        android:width="2dp"
+        android:color="@color/teal_200" />
+</shape>

--- a/Breaking/app/src/main/res/drawable/finance_self_background.xml
+++ b/Breaking/app/src/main/res/drawable/finance_self_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="8dip" />
+    <solid android:color="@color/white" />
+    <stroke
+        android:width="2dp"
+        android:color="@color/breaking_color" />
+</shape>

--- a/Breaking/app/src/main/res/drawable/text_click_background.xml
+++ b/Breaking/app/src/main/res/drawable/text_click_background.xml
@@ -8,6 +8,7 @@
     <item android:state_pressed="false">
         <shape>
             <solid android:color="@color/white" />
+            <stroke android:width="0.03dp" />
         </shape>
     </item>
 </selector>

--- a/Breaking/app/src/main/res/layout/activity_finance.xml
+++ b/Breaking/app/src/main/res/layout/activity_finance.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".FinanceActivity">
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="0.1dp"
+        android:background="@color/sign_up_input_hint_text_color"
+        app:layout_constraintBottom_toTopOf="@id/tl_finance" />
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/tb_finance"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/white"
+        android:elevation="2dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0"
+        app:navigationIcon="@drawable/ic_baseline_arrow_back_black_24"
+        app:title="거래 내역"
+        app:titleTextColor="@color/black" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_assessment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/border_white_background"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintHeight_percent="0.07"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.11"
+        app:layout_constraintWidth_percent="0.82">
+
+        <TextView
+            android:id="@+id/tv_assessment_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/balance"
+            android:textColor="@color/black"
+            android:textSize="15sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toLeftOf="@id/tv_assessment_value"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_assessment_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/breaking_color"
+            android:textSize="15sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintHorizontal_bias="0.2"
+            app:layout_constraintLeft_toRightOf="@id/tv_assessment_title"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/vp_finance"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tl_finance" />
+
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tl_finance"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/cl_assessment"
+        app:layout_constraintVertical_bias="0.05"
+        app:layout_constraintWidth_percent="1"
+        app:tabGravity="center"
+        app:tabIndicatorColor="@color/breaking_color"
+        app:tabIndicatorHeight="3dp" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Breaking/app/src/main/res/layout/activity_setting.xml
+++ b/Breaking/app/src/main/res/layout/activity_setting.xml
@@ -15,32 +15,89 @@
         android:elevation="2dp"
         app:title="설정"
         app:titleTextColor="@color/black" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
         <TextView
-            android:padding="5dp"
-            android:textColor="@color/black"
-            android:id="@+id/tv_account_title"
-            android:textSize="12sp"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintBottom_toTopOf="@id/tv_log_out"
-            app:layout_constraintHorizontal_bias="0.05"
-            app:layout_constraintVertical_bias="0.015"
+            android:id="@+id/tv_finance_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="계정"/>
-        <TextView
+            android:padding="5dp"
+            android:text="@string/transaction"
             android:textColor="@color/black"
-            android:id="@+id/tv_log_out"
-            android:background="@drawable/text_click_background"
-            android:text="로그아웃"
-            android:padding="17dp"
-            app:layout_constraintLeft_toLeftOf="@id/tv_account_title"
-            app:layout_constraintTop_toBottomOf="@id/tv_account_title"
+            android:textSize="12sp"
+            app:layout_constraintBottom_toTopOf="@id/cl_finance_value"
+            app:layout_constraintHorizontal_bias="0.05"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.015" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_finance_value"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            android:background="@drawable/text_click_background"
+            android:clickable="true"
+            android:padding="17dp"
+            app:layout_constraintLeft_toLeftOf="@id/tv_finance_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_finance_title">
+
+            <TextView
+                android:id="@+id/tv_finance_prefix"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/balance"
+                android:textColor="@color/black"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_finance_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/breaking_color"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="@id/tv_finance_prefix"
+                app:layout_constraintHorizontal_bias="0.15"
+                app:layout_constraintLeft_toRightOf="@id/tv_finance_prefix"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toTopOf="@id/tv_finance_prefix" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/tv_account_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="5dp"
+            android:text="@string/account"
+            android:textColor="@color/black"
+            android:textSize="12sp"
+            app:layout_constraintBottom_toTopOf="@id/tv_log_out"
+            app:layout_constraintHorizontal_bias="0.05"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.015" />
+
+        <TextView
+            android:id="@+id/tv_log_out"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/text_click_background"
+            android:padding="17dp"
+            android:text="@string/log_out"
+            android:textColor="@color/black"
+            app:layout_constraintLeft_toLeftOf="@id/tv_account_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_account_title" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </LinearLayout>

--- a/Breaking/app/src/main/res/layout/fragment_finance_charge.xml
+++ b/Breaking/app/src/main/res/layout/fragment_finance_charge.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/btn_charge"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/sign_up_button_background"
+        android:text="@string/do_charge"
+        android:textColor="@color/white"
+        android:textSize="12sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintHeight_percent="0.06"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/et_input_charge"
+        app:layout_constraintVertical_bias="0.09"
+        app:layout_constraintWidth_percent="0.3" />
+
+    <EditText
+        android:id="@+id/et_input_charge"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/input_background"
+        android:gravity="center"
+        android:hint="@string/hint_charge"
+        android:inputType="number"
+        android:maxLength="9"
+        android:maxLines="1"
+        android:padding="7dp"
+        android:textSize="13sp"
+        app:layout_constraintBottom_toBottomOf="@id/tv_charge_title"
+        app:layout_constraintHorizontal_bias="0.25"
+        app:layout_constraintLeft_toRightOf="@id/tv_charge_title"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tv_charge_title"
+        app:layout_constraintWidth_percent="0.6" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/won"
+        android:textColor="@color/black"
+        android:textSize="13sp"
+        app:layout_constraintBottom_toBottomOf="@id/et_input_charge"
+        app:layout_constraintHorizontal_bias="0.15"
+        app:layout_constraintLeft_toRightOf="@id/et_input_charge"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="@id/et_input_charge" />
+
+    <TextView
+        android:id="@+id/tv_charge_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/amount_charge"
+        android:textColor="@color/black"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintHorizontal_bias="0.1"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.2" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Breaking/app/src/main/res/layout/fragment_finance_transaction.xml
+++ b/Breaking/app/src/main/res/layout/fragment_finance_transaction.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/tv_finance_empty"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="@string/no_transaction_list"
+        android:textColor="@color/black"
+        android:textSize="15sp"
+        android:textStyle="bold"
+        android:visibility="gone" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rcv_finance"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:overScrollMode="never"
+        android:scrollbarAlwaysDrawVerticalTrack="true"
+        android:scrollbarSize="5dp"
+        android:scrollbars="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Breaking/app/src/main/res/layout/fragment_finance_withdraw.xml
+++ b/Breaking/app/src/main/res/layout/fragment_finance_withdraw.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/btn_withdraw"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/sign_up_button_background"
+        android:text="@string/do_withdraw"
+        android:textColor="@color/white"
+        android:textSize="12sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintHeight_percent="0.06"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/et_input_withdraw"
+        app:layout_constraintVertical_bias="0.09"
+        app:layout_constraintWidth_percent="0.3" />
+
+    <EditText
+        android:id="@+id/et_input_withdraw"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@drawable/input_background"
+        android:gravity="center"
+        android:hint="@string/hint_withdraw"
+        android:inputType="number"
+        android:maxLength="9"
+        android:maxLines="1"
+        android:padding="7dp"
+        android:textSize="13sp"
+        app:layout_constraintBottom_toBottomOf="@id/tv_withdraw_title"
+        app:layout_constraintHorizontal_bias="0.25"
+        app:layout_constraintLeft_toRightOf="@id/tv_withdraw_title"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tv_withdraw_title"
+        app:layout_constraintWidth_percent="0.6" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/won"
+        android:textColor="@color/black"
+        android:textSize="13sp"
+        app:layout_constraintBottom_toBottomOf="@id/et_input_withdraw"
+        app:layout_constraintHorizontal_bias="0.15"
+        app:layout_constraintLeft_toRightOf="@id/et_input_withdraw"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="@id/et_input_withdraw" />
+
+    <TextView
+        android:id="@+id/tv_withdraw_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/withdraw_amount"
+        android:textColor="@color/black"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintHorizontal_bias="0.1"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.2" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Breaking/app/src/main/res/layout/item_transaction_other.xml
+++ b/Breaking/app/src/main/res/layout/item_transaction_other.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="5dp"
+    android:background="@drawable/finance_other_background"
+    android:padding="3dp">
+
+    <TextView
+        android:id="@+id/tv_other_transaction_method"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:gravity="center"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintHorizontal_bias="0.02"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_percent="0.1" />
+
+    <TextView
+        android:id="@+id/tv_other_transaction_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textColor="@color/black"
+        android:textSize="13sp"
+        app:layout_constraintBottom_toTopOf="@id/tv_other_transaction_date"
+        app:layout_constraintHorizontal_bias="0.35"
+        app:layout_constraintLeft_toRightOf="@id/tv_other_transaction_method"
+        app:layout_constraintRight_toLeftOf="@id/tv_other_transaction_var"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.1"
+        app:layout_constraintWidth_percent="0.5" />
+
+    <TextView
+        android:id="@+id/tv_other_transaction_var"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:textSize="13sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/tv_other_transaction_method"
+        app:layout_constraintHorizontal_bias="0.97"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tv_other_transaction_method"
+        app:layout_constraintVertical_bias="0.1"
+        app:layout_constraintWidth_percent="0.27" />
+
+    <TextView
+        android:id="@+id/tv_other_transaction_date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="11sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="@id/tv_other_transaction_title"
+        app:layout_constraintTop_toBottomOf="@id/tv_other_transaction_title"
+        app:layout_constraintVertical_bias="1" />
+
+    <TextView
+        android:id="@+id/tv_other_transaction_balance"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="11.5sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="@id/tv_other_transaction_var"
+        app:layout_constraintRight_toRightOf="@id/tv_other_transaction_var"
+        app:layout_constraintTop_toBottomOf="@id/tv_other_transaction_var"
+        app:layout_constraintVertical_bias="0" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Breaking/app/src/main/res/layout/item_transaction_self.xml
+++ b/Breaking/app/src/main/res/layout/item_transaction_self.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="5dp"
+    android:background="@drawable/finance_self_background"
+    android:padding="3dp">
+
+    <TextView
+        android:id="@+id/tv_self_transaction_method"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:gravity="center"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintHorizontal_bias="0.02"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_percent="0.1" />
+
+    <TextView
+        android:id="@+id/tv_self_transaction_var"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:textSize="13sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/tv_self_transaction_method"
+        app:layout_constraintHorizontal_bias="0.97"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tv_self_transaction_method"
+        app:layout_constraintVertical_bias="0.1"
+        app:layout_constraintWidth_percent="0.27" />
+
+    <TextView
+        android:id="@+id/tv_self_transaction_date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/black"
+        android:textSize="13sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/tv_self_transaction_method"
+        app:layout_constraintHorizontal_bias="0.25"
+        app:layout_constraintLeft_toRightOf="@id/tv_self_transaction_method"
+        app:layout_constraintRight_toLeftOf="@id/tv_self_transaction_var"
+        app:layout_constraintTop_toTopOf="@id/tv_self_transaction_method" />
+
+    <TextView
+        android:id="@+id/tv_self_transaction_balance"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="11.5sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="@id/tv_self_transaction_var"
+        app:layout_constraintRight_toRightOf="@id/tv_self_transaction_var"
+        app:layout_constraintTop_toBottomOf="@id/tv_self_transaction_var"
+        app:layout_constraintVertical_bias="0" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Breaking/app/src/main/res/values/strings.xml
+++ b/Breaking/app/src/main/res/values/strings.xml
@@ -99,4 +99,16 @@
     <string name="hashtag_alert">해시태그 검색 시 맨 앞에 #을 붙여주세요. ex) #해시태그</string>
     <string name="user_alert">유저 검색 시 맨 앞에 @을 붙여주세요. ex) @홍길동</string>
     <string name="no_search_result">검색결과 없음</string>
+    <string name="no_transaction_list">입출금 내역이 없습니다.</string>
+    <string name="transaction">거래</string>
+    <string name="balance">보유 금액</string>
+    <string name="log_out">로그아웃</string>
+    <string name="account">계정</string>
+    <string name="amount_charge">충전 금액</string>
+    <string name="hint_charge">충전 금액을 입력하세요.</string>
+    <string name="won">원</string>
+    <string name="do_charge">충전하기</string>
+    <string name="do_withdraw">출금하기</string>
+    <string name="hint_withdraw">출금할 금액을 입력하세요.</string>
+    <string name="withdraw_amount">출금 금액</string>
 </resources>


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #101

## 예상 리뷰 시간
15-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 마이페이지 -> 설정 페이지에 "거래" 카테고리로 본인의 "보유 금액" 및 충전/출금, 입출금 내역을 확인할 수 있는 란 생성
  - 거래 내역 페이지 생성
- 거래 내역 페이지에 현재 보유하고 있는 금액을 표시
  - 중간에 3개의 탭으로 구성하여 기능 구현
    - 충전하기
      - 본인의 계좌에 돈을 충전하는 기능 (입금)
    - 출금하기
      - 본인의 계좌에서 돈을 출금하는 기능 (출금
    - 입출금 내역
      - cursor와 size로 pagination으로 리스트 구현
      - 로딩 아이템 메커니즘으로 구현
      - 구매, 판매, 충전, 출금에 대한 모든 입출금 기록을 보여주는 리스트 구현
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
- 설정 페이지 접속 시 뜨는 페이지
<img src="https://user-images.githubusercontent.com/54919474/188258737-49ad0637-c9cd-470b-b131-90557ce2b3d9.png" width="30%" height="30%"/>

- 보유 금액 칸 클릭 시 "거래 내역" 페이지로 이동 및 초기 화면
<img src="https://user-images.githubusercontent.com/54919474/188258739-12ae5e8c-6227-4c1c-b5bc-ff9981a865dc.png" width="30%" height="30%"/>

- "출금하기" 탭으로 이동
<img src="https://user-images.githubusercontent.com/54919474/188258741-d3d0d367-041f-4d58-83db-ab265ce9336c.png" width="30%" height="30%"/>

- "입출금 내역" 탭으로 이동 시 입출금 리스트 
<img src="https://user-images.githubusercontent.com/54919474/188258745-2a20931e-49e9-4c6d-9bc3-0ee71f1f2194.png" width="30%" height="30%"/>

- "충전하기" 탭에서 값을 입력 후 버튼 클릭 시 다이얼로그 
<img src="https://user-images.githubusercontent.com/54919474/188258751-11d08a36-fe28-43ac-96be-726c23528fa9.png" width="30%" height="30%"/>

- 최종 버튼 클릭 시, 화면 종료 및 설정 페이지에 변동된 금액 업데이트
<img src="https://user-images.githubusercontent.com/54919474/188258756-8093acd7-852c-4a6a-a13f-f34c0be3dc2a.png" width="30%" height="30%"/>

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 충전/출금 기능을 통해 보유 금액을 "거래 내역" 페이지에서 바로 업데이트 시키고 싶었지만 Tab Fragment에서 Activity로 값을 전달하거나 이벤트 트리거링을 하는 방법을 몰라서 화면을 종료시키는 방식으로 대체하였다. 
- 아직 구매 기능이 구현되지 않아 구매/판매 내역에 대한 아이템을 입출금 내역에서 확인해보지는 못했다. 그래서 임의로 테스트 데이터를 생성하여 추가함으로써 확인은 하였다. 