### PR TITLE
feat: implement refresh main feed 

### DIFF
--- a/Breaking/app/build.gradle
+++ b/Breaking/app/build.gradle
@@ -94,6 +94,9 @@ dependencies {
     // ViewPager2
     implementation "androidx.viewpager2:viewpager2:1.0.0"
 
+    // SwiperRefreshLayout
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
+
     // libs 폴더 접근 인식
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation files('libs/libDaumMapAndroid.jar')

--- a/Breaking/app/src/main/java/com/dope/breaking/util/DialogUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/DialogUtil.kt
@@ -223,8 +223,8 @@ class DialogUtil {
                     context,
                     this@FilterOptionDialog,
                     today.get(Calendar.YEAR),
-                    today.get(Calendar.DAY_OF_MONTH),
-                    today.get(Calendar.MONTH)
+                    today.get(Calendar.MONTH) + 1,
+                    today.get(Calendar.DAY_OF_MONTH)
                 ) // DatePicker 객체 생성
                 datePicker.datePicker.maxDate = today.timeInMillis // 최대 선택 가능한 날짜를 오늘로 설정
                 datePicker.show() // DatePicker 실행
@@ -238,8 +238,8 @@ class DialogUtil {
                     context,
                     this@FilterOptionDialog,
                     today.get(Calendar.YEAR),
-                    today.get(Calendar.DAY_OF_MONTH),
-                    today.get(Calendar.MONTH)
+                    today.get(Calendar.MONTH) + 1,
+                    today.get(Calendar.DAY_OF_MONTH)
                 ) // DatePicker 객체 생성
                 datePicker.datePicker.maxDate = today.timeInMillis // 최대 선택 가능한 날짜를 오늘로 설정
                 datePicker.show() // DatePicker 실행

--- a/Breaking/app/src/main/res/layout/fragment_navi_home.xml
+++ b/Breaking/app/src/main/res/layout/fragment_navi_home.xml
@@ -50,11 +50,11 @@
             android:id="@+id/et_search_bar"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:inputType="none"
-            android:focusable="false"
-            android:clickable="true"
-            android:padding="3dp"
             android:background="@drawable/main_search_background"
+            android:clickable="true"
+            android:focusable="false"
+            android:inputType="none"
+            android:padding="3dp"
             android:textSize="13sp"
             app:layout_constraintBottom_toBottomOf="@id/imgv_main_logo"
             app:layout_constraintHeight_percent="0.05"
@@ -63,6 +63,30 @@
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toTopOf="@id/imgv_main_logo"
             app:layout_constraintWidth_percent="0.6" />
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/hashtag_bottom_divider"
+            app:layout_constraintVertical_bias="0.05">
+
+            <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+                android:id="@+id/srl_main_feed"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rcv_main_feed"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:overScrollMode="never"
+                    android:scrollbarAlwaysDrawVerticalTrack="true"
+                    android:scrollbarSize="5dp"
+                    android:scrollbars="vertical"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+            </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+        </FrameLayout>
 
         <ImageView
             android:id="@+id/imgv_search_icon"
@@ -148,19 +172,6 @@
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toBottomOf="@id/hashtag_top_divider" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rcv_main_feed"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:overScrollMode="never"
-            android:scrollbarAlwaysDrawVerticalTrack="true"
-            android:scrollbarSize="5dp"
-            android:scrollbars="vertical"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/hashtag_bottom_divider"
-            app:layout_constraintVertical_bias="0.05" />
 
         <com.facebook.shimmer.ShimmerFrameLayout
             android:id="@+id/sfl_post_list_skeleton"


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #109 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 필터 옵션에서 "날짜" 옵션에서 Date Picker 호출 시, 오늘 날짜가 이상하게 나오던 버그 해결
- 메인 피드에 `SwipeRefreshLayout` View 추가
  - Swipe 시, 메인 피드 데이터 갱신 (필터, 정렬 옵션 포함된 채로)
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
- Swipe가 순식간이라 캡처하지 못함 피드 리스트에서 위에서 아래로 당기면 리프레시 동작
## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- RecyclerView의 부모로 SwipeRefreshLayout을 사용하면 전체 뷰가 화면 공간을 넘치게 되는 현상이 있었다. 
  - FrameLayout을 SwipeRefreshLayout에 감싸주어 해결해주었다. 