### PR TITLE
hotfix: add condition for renew data by scroll event

### DIFF
--- a/Breaking/app/src/main/java/com/dope/breaking/FinanceActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/FinanceActivity.kt
@@ -2,6 +2,7 @@ package com.dope.breaking
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.recyclerview.widget.RecyclerView
 import com.dope.breaking.adapter.FinanceViewPagerAdapter
 import com.dope.breaking.databinding.ActivityFinanceBinding
 import com.dope.breaking.model.response.ResponseExistLogin
@@ -34,12 +35,15 @@ class FinanceActivity : AppCompatActivity() {
     /**
      * 탭 레이아웃 초기 설정 함수
      * @author Seunggun Sin
-     * @since 2022-09-02
+     * @since 2022-09-02 | 2022-09-04
      */
     private fun initTabLayout() {
         binding.vpFinance.adapter = FinanceViewPagerAdapter(
             supportFragmentManager, lifecycle
         )
+        binding.vpFinance.getChildAt(0).overScrollMode =
+            RecyclerView.OVER_SCROLL_NEVER // viewpager overscroll 이펙트 제거
+
         TabLayoutMediator(binding.tlFinance, binding.vpFinance) { tab, position ->
             tab.text = ValueUtil.FINANCE_TAB_TEXT[position]
         }.attach()

--- a/Breaking/app/src/main/java/com/dope/breaking/UserPageActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/UserPageActivity.kt
@@ -10,6 +10,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.Toolbar
+import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
@@ -256,11 +257,15 @@ class UserPageActivity : AppCompatActivity() {
     /**
      * 게시글 레이아웃 부분 설정
      * @author Seunggun Sin
-     * @since 2022-07-29
+     * @since 2022-07-29 | 2022-09-04
      */
     private fun setPostLayout(userId: Long) {
         val viewPager = findViewById<ViewPager2>(R.id.view_pager) // ViewPager2 객체
         val tabLayout = findViewById<TabLayout>(R.id.tab_layout) // TabLayout 객체
+
+        viewPager.getChildAt(0).overScrollMode =
+            RecyclerView.OVER_SCROLL_NEVER // viewpager overscroll 이펙트 제거
+
         viewPager.adapter =
             UserViewPagerAdapter(supportFragmentManager, lifecycle, userId) // ViewPager 어댑터 지정
 

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviUserFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/NaviUserFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.*
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.dope.breaking.*
@@ -86,7 +87,7 @@ class NaviUserFragment : Fragment() {
      * 이 Fragment 호출 시 초기 화면에 보여줄 View 세팅 함수
      * @param userData(User): 로딩 Fragment 로 부터 받아온 유저 프로필 객체
      * @author Seunggun Sin
-     * @since 2022-07-21 | 2022-07-22
+     * @since 2022-07-21 | 2022-09-04
      */
     private fun initProfileView(userData: User) {
         /*
@@ -115,6 +116,10 @@ class NaviUserFragment : Fragment() {
 
         val viewPager = binding.viewPager // ViewPager2 객체
         val tabLayout = binding.tabLayout // TabLayout 객체
+
+        viewPager.getChildAt(0).overScrollMode =
+            RecyclerView.OVER_SCROLL_NEVER // viewpager overscroll 이펙트 제거
+
         viewPager.adapter =
             UserViewPagerAdapter(
                 parentFragmentManager,

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/BookmarkedTabFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/BookmarkedTabFragment.kt
@@ -94,7 +94,7 @@ class BookmarkedTabFragment : Fragment() {
                     // 스크롤이 드래깅 중이면서
                     // 피드 요청이 더 가능하면서
                     // 로딩 중이 아니라면
-                    if (lastIndex == recyclerView.adapter!!.itemCount - 1 && !isObtainAll && !isLoading) {
+                    if (lastIndex == recyclerView.adapter!!.itemCount - 1 && newState == 2 && !isObtainAll && !isLoading) {
                         processGetUserFeed(
                             userId, // 가져올 대상의 유저 id
                             userFeedMutableList[lastIndex]!!.postId, // 다음 요청에 필요한 마지막 게시글 id

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/PostTabFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/PostTabFragment.kt
@@ -93,7 +93,7 @@ class PostTabFragment : Fragment() {
                     // 스크롤이 드래깅 중이면서
                     // 피드 요청이 더 가능하면서
                     // 로딩 중이 아니라면
-                    if (lastIndex == recyclerView.adapter!!.itemCount - 1 && !isObtainAll && !isLoading) {
+                    if (lastIndex == recyclerView.adapter!!.itemCount - 1 && newState == 2 && !isObtainAll && !isLoading) {
                         processGetUserFeed(
                             userId, // 가져올 대상의 유저 id
                             userFeedMutableList[lastIndex]!!.postId, // 다음 요청에 필요한 마지막 게시글 id

--- a/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/PurchasedTabFragment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/fragment/user_tab/PurchasedTabFragment.kt
@@ -93,7 +93,7 @@ class PurchasedTabFragment : Fragment() {
                     // 스크롤이 드래깅 중이면서
                     // 피드 요청이 더 가능하면서
                     // 로딩 중이 아니라면
-                    if (lastIndex == recyclerView.adapter!!.itemCount - 1 && !isObtainAll && !isLoading) {
+                    if (lastIndex == recyclerView.adapter!!.itemCount - 1 && newState == 2 && !isObtainAll && !isLoading) {
                         processGetUserFeed(
                             userId, // 가져올 대상의 유저 id
                             userFeedMutableList[lastIndex]!!.postId, // 다음 요청에 필요한 마지막 게시글 id

--- a/Breaking/app/src/main/java/com/dope/breaking/util/ValueUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/ValueUtil.kt
@@ -18,12 +18,12 @@ class ValueUtil {
         const val REFRESH_JWT_HEADER_KEY = "authorization-refresh" // refresh token 키 값
         const val JWT_REQUEST_PREFIX = "Bearer " // Jwt 토큰을 헤더에 넣고 요청할 때 필요한 접두사
         const val FILTER_DATE_FORMAT_SUFFIX = "T00:00" // 피드 요청 시 "기간" 필터의 날짜 형식에 대한 접미사
-        const val FEED_SIZE = 10 // 피드 요청마다 가져올 게시글 개수
+        const val FEED_SIZE = 15 // 피드 요청마다 가져올 게시글 개수
         const val FOLLOW_SIZE = 15 // 팔로우 리스트 요청 시 가져올 아이템 개수
         const val VIEW_TYPE_ITEM = 0 // 일반 아이템에 대한 레이아웃 view type
         const val VIEW_TYPE_LOADING = 1 // 로딩 아이템에 대한 레이아웃 view type
-        const val USER_FEED_SIZE = 6 // 유저 페이지 피드 요청마다 가져올 게시글 개수
-        const val TRANSACTION_SIZE = 20 // 입출금 내역 리스트 가져올 개수
+        const val USER_FEED_SIZE = 10 // 유저 페이지 피드 요청마다 가져올 게시글 개수
+        const val TRANSACTION_SIZE = 25 // 입출금 내역 리스트 가져올 개수
         const val COMMENT_SIZE = 3 // 댓글 요청마다 가져올 댓글 개수
         const val NESTED_COMMENT_SIZE = 10 // 대댓글 요청마다 가져올 대댓글 개수
 

--- a/Breaking/app/src/main/res/layout/fragment_bookmarked_tab.xml
+++ b/Breaking/app/src/main/res/layout/fragment_bookmarked_tab.xml
@@ -65,7 +65,7 @@
         android:layout_height="wrap_content"
         android:overScrollMode="never"
         android:scrollbarAlwaysDrawVerticalTrack="true"
-        android:scrollbarSize="8dp"
+        android:scrollbarSize="5dp"
         android:scrollbars="vertical"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 

--- a/Breaking/app/src/main/res/layout/fragment_post_tab.xml
+++ b/Breaking/app/src/main/res/layout/fragment_post_tab.xml
@@ -64,7 +64,7 @@
         android:layout_height="wrap_content"
         android:overScrollMode="never"
         android:scrollbarAlwaysDrawVerticalTrack="true"
-        android:scrollbarSize="8dp"
+        android:scrollbarSize="5dp"
         android:scrollbars="vertical"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 

--- a/Breaking/app/src/main/res/layout/fragment_purchased_tab.xml
+++ b/Breaking/app/src/main/res/layout/fragment_purchased_tab.xml
@@ -65,7 +65,7 @@
         android:layout_height="wrap_content"
         android:overScrollMode="never"
         android:scrollbarAlwaysDrawVerticalTrack="true"
-        android:scrollbarSize="8dp"
+        android:scrollbarSize="5dp"
         android:scrollbars="vertical"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #113 

## 예상 리뷰 시간
2-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 유저 페이지 피드에서 스크롤 이벤트로 데이터 갱신 시 이상한(?) 움직임으로 갱신하는 문제가 있었는데,  스크롤 리스너의 parameter인 `newState==2` 조건을 까먹고 추가하지 않아 추가해줌으로써 해결해주었다. 
- 유저 페이지 피드 스크롤 바 크기 조정
- view pager가 사용되는 모든 곳에서 view pager의 overscroll 이펙트 삭제
- pagination에서 가져오는 아이템 개수 증가
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
x
## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- ViewPager2의 경우 xml상에서 overScrollMode가 먹히지 않아 코드 상으로 설정해 해결해주었다. 