### PR TITLE
feat: Implement post detail like component

### DIFF
--- a/Breaking/app/src/main/AndroidManifest.xml
+++ b/Breaking/app/src/main/AndroidManifest.xml
@@ -16,13 +16,18 @@
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="false"
+        android:hardwareAccelerated="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:largeHeap="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Breaking"
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
+        <activity
+            android:name=".board.PostLikeActivity"
+            android:exported="false" />
         <activity
             android:name=".EditPostActivity"
             android:exported="false" />

--- a/Breaking/app/src/main/java/com/dope/breaking/board/PostLikeActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/board/PostLikeActivity.kt
@@ -1,0 +1,252 @@
+package com.dope.breaking.board
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.util.Log
+import android.view.MenuItem
+import android.view.View
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.dope.breaking.R
+import com.dope.breaking.adapter.FollowAdapter
+import com.dope.breaking.databinding.ActivityFollowBinding
+import com.dope.breaking.exception.ResponseErrorException
+import com.dope.breaking.model.FollowData
+import com.dope.breaking.model.response.ResponseExistLogin
+import com.dope.breaking.post.PostManager
+import com.dope.breaking.util.DialogUtil
+import com.dope.breaking.util.JwtTokenUtil
+import com.dope.breaking.util.ValueUtil
+import com.facebook.shimmer.ShimmerFrameLayout
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class PostLikeActivity : AppCompatActivity() {
+    private val TAG = "PostLikeActivity.kt"
+    private var mbinding : ActivityFollowBinding? = null
+    private val binding get() = mbinding!!
+    private var likeList = mutableListOf<FollowData?>() // 좋아요 목록 저장하는 리스트
+    private var isLoading = false // 로딩 중 판단
+    private var isObtainedAll = false // 더 이상 얻을 리스트 있는지 판단
+    private var postId = -1 // 좋아요 목록을 가져올 게시물 id
+    private lateinit var adapterLikeList: FollowAdapter // 좋아요 리스트 어댑터 (팔로잉 어댑터 재사용)
+    private lateinit var progressBar: ProgressBar
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var shimmerFrameLayout: ShimmerFrameLayout
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        mbinding = ActivityFollowBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val token =
+            ValueUtil.JWT_REQUEST_PREFIX + JwtTokenUtil(this).getAccessTokenFromLocal()
+
+        postId = intent.getIntExtra("postId",-1) // postId 가져오기
+
+        progressBar = findViewById(R.id.progressbar_loading)
+        recyclerView = findViewById(R.id.rcv_following)
+        shimmerFrameLayout = findViewById(R.id.sfl_follow_list_skeleton)
+
+        adapterLikeList = FollowAdapter(this, likeList, false, -1) // 초기 어댑터 지정
+
+        /*
+           최초 좋아요 리스트 요청
+         */
+        processGetPostLikeList(
+            token,
+            postId.toLong(),
+            0, {
+                showSkeletonView() // 스켈레톤 UI 시작
+                isLoading = true
+            },{
+                adapterLikeList.addItems(it)
+
+                if (likeList.size == 0) { // 목록 없을 때
+                    handleEmptyList() // 빈 레이아웃 처리하기
+                } else {
+                    setToolbar() // 툴바 설정
+                    extractMyselfItem() // 본인이 있다면 최상단으로 올리기
+                }
+                recyclerView.adapter = adapterLikeList // 리사이클러 뷰에 어댑터 설정
+
+                /*
+                  스크롤 이벤트 지정
+                */
+                recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+                    override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                        super.onScrollStateChanged(recyclerView, newState)
+
+                        val lastIndex =
+                            (recyclerView.layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition()
+
+                        // 가져온 아이템 사이즈가 가져와야하는 사이즈보다 작은 경우 새로운 요청을 못하게 막기
+                        if (recyclerView.adapter!!.itemCount < ValueUtil.FOLLOW_SIZE) {
+                            return
+                        }
+
+                        // 실제 데이터 리스트의 마지막 인덱스와 스크롤 이벤트에 의한 인덱스 값이 같으면서
+                        // 스크롤이 드래깅 중이면서
+                        // 피드 요청이 더 가능하면서
+                        // 로딩 중이 아니라면
+                        if (lastIndex == recyclerView.adapter!!.itemCount - 1 && newState == 2 && !isObtainedAll && !isLoading) {
+                            processGetPostLikeList(
+                                token,
+                                postId.toLong(),
+                                likeList[lastIndex]!!.cursorId, { // 마지막 인덱스
+                                    adapterLikeList.addItem(null) // 로딩 아이템 추가
+                                    isLoading = true // 로딩 상태 on
+                                },
+                                { it2 ->
+                                    if (it2.size < ValueUtil.FOLLOW_SIZE) { // 정량으로 가져오는 개수보다 적다면
+                                        adapterLikeList.removeLast() // 먼저 로딩 아이템 제거
+                                        if (it2.isNotEmpty()) { // 리스트가 비어있지 않다면
+                                            adapterLikeList.addItems(it2) // 받아온 리스트 추가
+                                        }
+                                        isObtainedAll = true // 더 이상 받아올 피드가 없다는 상태로 전환
+                                    } else { // 리스트가 있다면
+                                        adapterLikeList.removeLast() // 먼저 로딩 아이템 제거
+                                        adapterLikeList.addItems(it2) // 받아온 리스트 추가
+                                    }
+
+                                    extractMyselfItem() // 새로 업데이트할 때마다 본인 아이템 있는 경우 최상단으로 옮기기
+                                    isLoading = false // 로딩 상태 off
+                                },
+                                {
+                                    DialogUtil().SingleDialog(
+                                        this@PostLikeActivity,
+                                        "요청에 문제가 발생하였습니다.",
+                                        "확인"
+                                    ).show()
+                                })
+                        }
+                    }
+                })
+                dismissSkeletonView() // 스켈레톤 UI 종료
+                isLoading = false // 로딩 종료
+            },{
+                DialogUtil().SingleDialog(
+                    this@PostLikeActivity,
+                    "요청에 문제가 발생하였습니다.",
+                    "확인"
+                ).show()
+            })
+    }
+
+    /**
+     * @description - 게시물 좋아요 리스트 요청 함수를 호출하는 메소드
+     * @param - token(String) : JWT 토큰
+     * @param - postId(Long) : 좋아요 리스트를 요청할 게시물 id
+     * @param - lastUserId(Int) : 가장 최근에 요청한 유저 id
+     * @return - None
+     * @author - Tae hyun Park
+     * @since - 2022-09-06
+     */
+    private fun processGetPostLikeList(
+        token: String,
+        postId : Long,
+        lastUserId : Int,
+        init: () -> Unit,
+        last: (List<FollowData>) -> Unit,
+        error: (ResponseErrorException) -> Unit
+    ){
+        CoroutineScope(Dispatchers.Main).launch {
+            init() // 초기화 함수 호출
+            val postManager = PostManager() // 커스텀 게시글 객체 생성
+            try {
+                val response = postManager.startGetPostLikeList(
+                    token,
+                    postId,
+                    lastUserId,
+                    ValueUtil.LIKE_SIZE,
+                )
+                last(response) // 받아온 리스트를 바탕으로 후처리 함수 호출
+                Log.d(TAG, "좋아요 리스트 요청 결과 : $response")
+            }catch (e: ResponseErrorException){
+                error(e)
+            }
+        }
+    }
+
+    /**
+     * 현재 리스트에서 본인이 포함되어있다면 맨 상단으로 이동시키는 함수
+     * @author Seunggun
+     * @since 2022-08-18
+     */
+    private fun extractMyselfItem() {
+        var i = 0
+        for (likeData in adapterLikeList.data) {
+            if (likeData!!.userId == ResponseExistLogin.baseUserInfo?.userId && i != 0) {
+                adapterLikeList.removeItem(likeData) // 현재 데이터 제거
+                adapterLikeList.addItemIndex(0, likeData) // 첫번째 인덱스에 추가
+                break
+            }
+            i++
+        }
+    }
+
+    /**
+     * 목록이 비어있을 때에 대한 화면 처리
+     * @author Seunggun Sin | Tae hyun Park
+     * @since 2022-07-28 | 2022-09-07
+     */
+    private fun handleEmptyList() {
+        setContentView(R.layout.empty_layout_for_no_item)
+        setToolbar() // 툴바 설정
+        findViewById<TextView>(R.id.alert_text).text = "좋아요 목록이 없습니다."
+    }
+
+    /**
+     * 좋아요 페이지 툴바 설정
+     * @author Seunggun Sin | Tae hyun Park
+     * @since 2022-07-28 | 2022-09-07
+     */
+    private fun setToolbar() {
+        val toolbar = findViewById<Toolbar>(R.id.following_tool_bar)
+        toolbar.title = "좋아요 목록" // 툴바 타이틀 설정
+        // 뒤로가기 버튼 설정
+        toolbar.setNavigationIcon(R.drawable.ic_baseline_arrow_back_black_24)
+        toolbar.setNavigationOnClickListener {
+            finish()
+        }
+    }
+
+    /**
+     * 스켈레톤 UI를 보여주는 함수 with shimmer effect
+     * @author Seunggun Sin
+     * @since 2022-08-25
+     */
+    private fun showSkeletonView() {
+        recyclerView.visibility = View.GONE
+        shimmerFrameLayout.visibility = View.VISIBLE
+        shimmerFrameLayout.startShimmer()
+    }
+
+    /**
+     * 스켈레톤 UI를 종료하는 함수
+     * @author Seunggun Sin
+     * @since 2022-08-25
+     */
+    private fun dismissSkeletonView() {
+        shimmerFrameLayout.stopShimmer()
+        shimmerFrameLayout.visibility = View.GONE
+        recyclerView.visibility = View.VISIBLE
+    }
+
+    /**
+     * 툴바 아이템 클릭 이벤트
+     */
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            android.R.id.home -> {
+                finish()
+                return true
+            }
+        }
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
@@ -186,7 +186,45 @@ interface RetrofitService {
         @Query("size") contentsSize: Int
     ): Response<List<ResponseComment>>
 
+    /**
+     * 해당 게시물의 좋아요를 요청하는 메소드
+     * @param - token(String) : jwt 토큰
+     * @Path  - postId(Long) : 좋아요를 요청할 게시글 id
+     * @author - Tae hyun Park
+     */
+    @POST("post/{postId}/like")
+    suspend fun requestPostLike(
+        @Header("authorization") token: String,
+        @Path("postId") postId: Long
+    ): Response<Unit>
 
+    /**
+     * 해당 게시물의 좋아요 취소를 요청하는 메소드
+     * @param - token(String) : jwt 토큰
+     * @Path  - postId(Long) : 취소를 요청할 게시글 id
+     * @author - Tae hyun Park
+     */
+    @DELETE("post/{postId}/like")
+    suspend fun requestCancelPostLike(
+        @Header("authorization") token: String,
+        @Path("postId") postId: Long
+    ): Response<Unit>
+
+    /**
+     * 해당 게시물의 좋아요 한 유저 리스트를 요청하는 메소드
+     * @param - token(String) : jwt 토큰
+     * @Path  - postId(Long) : 유저 리스트를 요청할 게시글 id
+     * @param lastUserId(Int) : 마지막으로 가져온 userId (처음 요청 시에는 0 or null)
+     * @param contentsSize(Int) : 가져올 유저 개수 (필수)
+     * @author - Tae hyun Park
+     */
+    @GET("post/{postId}/like-list")
+    suspend fun requestPostLikeList(
+        @Header("authorization") token: String,
+        @Path("postId") postId: Long,
+        @Query("cursor") lastUserId: Int,
+        @Query("size") contentsSize: Int
+    ): Response<List<FollowData>>
 
     /**
      * 구글 로그인 토큰 검증 요청 메소드

--- a/Breaking/app/src/main/java/com/dope/breaking/util/ValueUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/ValueUtil.kt
@@ -26,6 +26,7 @@ class ValueUtil {
         const val TRANSACTION_SIZE = 25 // 입출금 내역 리스트 가져올 개수
         const val COMMENT_SIZE = 3 // 댓글 요청마다 가져올 댓글 개수
         const val NESTED_COMMENT_SIZE = 10 // 대댓글 요청마다 가져올 대댓글 개수
+        const val LIKE_SIZE = 10 // 좋아요 리스트 요청마다 가져올 유저 개수
 
         val TAB_ICONS = arrayOf(
             R.drawable.ic_baseline_create_24,

--- a/Breaking/app/src/main/res/drawable/ic_post_comment.xml
+++ b/Breaking/app/src/main/res/drawable/ic_post_comment.xml
@@ -1,9 +1,13 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="20dp"
-    android:height="20dp"
-    android:viewportWidth="20"
-    android:viewportHeight="20">
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
   <path
-      android:pathData="M18,0H2C0.897,0 0,0.897 0,2V20L4,16H18C19.103,16 20,15.103 20,14V2C20,0.897 19.103,0 18,0Z"
-      android:fillColor="#000000"/>
+      android:pathData="M19,4H5C4.47,4 3.961,4.211 3.586,4.586C3.211,4.961 3,5.47 3,6V16C3,16.53 3.211,17.039 3.586,17.414C3.961,17.789 4.47,18 5,18H8.188C9.188,18 10,18.811 10,19.812C10,20.62 10.976,21.024 11.547,20.453L13.414,18.586C13.789,18.211 14.298,18 14.828,18H19C19.53,18 20.039,17.789 20.414,17.414C20.789,17.039 21,16.53 21,16V6C21,5.47 20.789,4.961 20.414,4.586C20.039,4.211 19.53,4 19,4V4Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
 </vector>

--- a/Breaking/app/src/main/res/drawable/ic_post_like_after.xml
+++ b/Breaking/app/src/main/res/drawable/ic_post_like_after.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M4,21H5V8H4C3.47,8 2.961,8.211 2.586,8.586C2.211,8.961 2,9.47 2,10V19C2,19.53 2.211,20.039 2.586,20.414C2.961,20.789 3.47,21 4,21ZM20,8H13L14.122,4.632C14.222,4.331 14.249,4.011 14.202,3.698C14.154,3.385 14.032,3.088 13.847,2.831C13.662,2.574 13.418,2.364 13.136,2.22C12.854,2.075 12.542,2 12.225,2H12L7,7.438V21H18L21.912,12.404L22,12V10C22,9.47 21.789,8.961 21.414,8.586C21.039,8.211 20.53,8 20,8Z"
+      android:fillColor="#014D91"/>
+</vector>

--- a/Breaking/app/src/main/res/layout/activity_post_detail.xml
+++ b/Breaking/app/src/main/res/layout/activity_post_detail.xml
@@ -355,12 +355,12 @@
                     android:id="@+id/tv_post_like_count"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    app:layout_constraintHorizontal_bias="0.01"
+                    app:layout_constraintHorizontal_bias="0"
                     android:textColor="@color/black"
                     android:textSize="10sp"
                     app:layout_constraintTop_toTopOf="@+id/ib_post_like"
                     app:layout_constraintBottom_toBottomOf="@+id/ib_post_like"
-                    app:layout_constraintLeft_toRightOf="@id/ib_post_like"
+                    app:layout_constraintLeft_toLeftOf="@id/tv_post_comment_count"
                     app:layout_constraintRight_toRightOf="parent" />
 
                 <ImageButton
@@ -368,23 +368,22 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:background="@drawable/ic_post_comment"
-                    app:layout_constraintHorizontal_bias="0.07"
-                    app:layout_constraintTop_toTopOf="@+id/ib_post_like"
-                    app:layout_constraintBottom_toBottomOf="@+id/ib_post_like"
-                    app:layout_constraintLeft_toRightOf="@id/ib_post_like"
-                    app:layout_constraintRight_toRightOf="parent"
-                    tools:layout_editor_absoluteY="356dp" />
+                    android:layout_marginTop="5dp"
+                    app:layout_constraintHorizontal_bias="0"
+                    app:layout_constraintTop_toBottomOf="@+id/ib_post_like"
+                    app:layout_constraintLeft_toLeftOf="@id/ib_post_like"
+                    app:layout_constraintRight_toRightOf="parent" />
 
                 <TextView
                     android:id="@+id/tv_post_comment_count"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:textColor="@color/black"
-                    app:layout_constraintHorizontal_bias="0.15"
+                    app:layout_constraintHorizontal_bias="0.01"
                     android:textSize="10sp"
-                    app:layout_constraintTop_toTopOf="@+id/ib_post_like"
-                    app:layout_constraintBottom_toBottomOf="@+id/ib_post_like"
-                    app:layout_constraintLeft_toRightOf="@id/ib_post_like"
+                    app:layout_constraintTop_toTopOf="@+id/ib_post_comment"
+                    app:layout_constraintBottom_toBottomOf="@+id/ib_post_comment"
+                    app:layout_constraintLeft_toRightOf="@id/ib_post_comment"
                     app:layout_constraintRight_toRightOf="parent" />
 
                 <ImageButton
@@ -407,7 +406,7 @@
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/ib_post_like" />
+                    app:layout_constraintTop_toBottomOf="@id/ib_post_comment" />
 
                 <TextView
                     android:id="@+id/tv_comment_none"


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #118 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
- 좋아요/좋아요 취소 기능을 구현했습니다.
  - 요청 함수를 구현하였습니다.
  - 좋아요/취소 갱신 로직을 다른 게시글 Refresh 로직에도 모두 포함시키도록 했습니다.(ex. 게시글 수정 시에 포스트가 다시 갱신되는데, 이 때 좋아요 여부도 다시 갱신되도록)
  - 좋아요/취소 시 이미 좋아요가 됐거나 취소가 된 경우, 갱신하도록 예외 처리했습니다.

- 좋아요 리스트 목록을 구현했습니다
  - 팔로잉/팔로워 어답터를 재사용하여 좋아요 옆 카운트 클릭 시 좋아요 한 유저의 리스트를 확인할 수 있도록 했습니다. 
  - 해당 어답터와 XML이 재사용되었기 때문에, 팔로우/팔로워 기능은 이전과 동일하게 사용 가능합니다.  

- 게시글 세부 조회 페이지의  좋아요, 댓글 아이콘과 배치를 변경하였습니다. 

## 스크린샷
- 게시글 좋아요
<img src="https://user-images.githubusercontent.com/31824443/188719559-3cd8e121-1754-4a6b-94a5-cd5d7a6a1ee1.png" width="30%" height="30%"/>
- 게시글 좋아요 요청
<img src="https://user-images.githubusercontent.com/31824443/188719717-3f242049-528d-4227-9b0f-acdbb2160ea0.png" width="30%" height="30%"/>
- 게시글 좋아요 목록
<img src="https://user-images.githubusercontent.com/31824443/188719791-a47b72e2-f7c6-4443-8bdd-05cd77af7e63.png" width="30%" height="30%"/>

## 기타
- 게시글 세부 조회에서 댓글, 대댓글, 수정, 좋아요 등의  다양한 이벤트가 일어날 시 게시글을 새롭게 갱신해야되는데, 갱신하는 로직이 많아져서 아예 Refresh용 메서드를 만들어 모듈화시켰다. (앞으로도 추가 예정)
