### PR TITLE
feat: Implement post detail comment like, modify, delete

### DIFF
--- a/Breaking/app/src/main/java/com/dope/breaking/board/PostDetailActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/board/PostDetailActivity.kt
@@ -1,7 +1,6 @@
 package com.dope.breaking.board
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
@@ -58,6 +57,7 @@ class PostDetailActivity : AppCompatActivity() {
     private var isPurchased = false // 해당 게시물을 내가 구매했는지
     private var isPurchasable = false // 해당 게시물이 활성화(true)인지, 비활성화(false)인지
     private var isSold = false // 해당 게시물이 1개 이상 팔렸는지
+    private var isContentButtonPressed = false // 게시물
     private var isMyPost = false // 해당 게시물의 작성자가 나인지
     private var postType = "" // 해당 게시물의 타입
     private var isLoading = false  // 로딩 중 판단
@@ -126,6 +126,16 @@ class PostDetailActivity : AppCompatActivity() {
 
         binding.tvUserNickName.setOnClickListener { // 프로필 닉네임 클릭 시 유저 프로필로 이동
             UserProfile(this).moveToUserPage(userId.toLong())
+        }
+
+        binding.tvPostContent.setOnClickListener {
+            if (!isContentButtonPressed){ // 제보 컨텐츠의 본문을 더 봐야 한다면
+                binding.tvPostContent.maxLines = 20 // 다 보이게 (20줄로 기본 설정)
+                isContentButtonPressed = true
+            } else{
+                binding.tvPostContent.maxLines = 10 // 다시 10줄로 설정
+                isContentButtonPressed = false
+            }
         }
 
         // 좋아요 클릭 리스너
@@ -341,7 +351,7 @@ class PostDetailActivity : AppCompatActivity() {
         }, { it ->
             commentList.addAll(it) // 어댑터에 넣어줄 댓글 리스트 데이터
             adapterComment =
-                PostCommentAdapter(this, commentList, token, binding) // 어댑터 정의
+                PostCommentAdapter(this, commentList, token, getPostId.toLong(), binding) // 어댑터 정의
             adapterComment.setItemReplyClickListener(object : PostCommentAdapter.OnItemClickListener{ // 답글 달기 클릭 리스너 등록
                 override fun onClick(v: View, position: Int) {
                     Log.d(TAG,"누른 댓글 id 테스트 : ${commentList[position]?.commentId}")

--- a/Breaking/app/src/main/java/com/dope/breaking/board/PostNestedCommentAdapter.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/board/PostNestedCommentAdapter.kt
@@ -6,22 +6,38 @@ import android.graphics.Color
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.*
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.dope.breaking.R
+import com.dope.breaking.databinding.ActivityPostDetailBinding
+import com.dope.breaking.databinding.CustomCommentMorePopupBinding
+import com.dope.breaking.exception.ResponseErrorException
+import com.dope.breaking.model.request.RequestComment
 import com.dope.breaking.model.response.ResponseComment
+import com.dope.breaking.model.response.ResponseExistLogin
+import com.dope.breaking.post.PostManager
 import com.dope.breaking.user.UserProfile
 import com.dope.breaking.util.DateUtil
+import com.dope.breaking.util.DialogUtil
 import com.dope.breaking.util.Utils
 import com.dope.breaking.util.ValueUtil
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class PostNestedCommentAdapter (
     private val context: Context,
-    var data: MutableList<ResponseComment?>
+    var token: String,
+    var data: MutableList<ResponseComment?>,
+    var commentId: Long,
+    var binding : ActivityPostDetailBinding
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>(){
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
@@ -36,7 +52,7 @@ class PostNestedCommentAdapter (
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         if (holder is ItemViewHolder) {
-            holder.bind(data[position]!!)
+            holder.bind(data[position]!!, position)
             holder.commentProfile.setOnClickListener { // 답글 프로필 클릭 시 이동
                 UserProfile(context as Activity).moveToUserPage(data[position]!!.user.userId)
             }
@@ -56,10 +72,15 @@ class PostNestedCommentAdapter (
         private val commentContent = itemView.findViewById<TextView>(R.id.tv_comment_content_nested)
         private val commentButtonLike = itemView.findViewById<ImageButton>(R.id.ib_post_like_nested)
         private val commentCountLike = itemView.findViewById<TextView>(R.id.tv_post_like_count_nested)
-        private val commentButtonMore = itemView.findViewById<ImageButton>(R.id.ib_post_more_nested)
         private val commentDate = itemView.findViewById<TextView>(R.id.tv_post_time_nested)
 
-        fun bind(item: ResponseComment){
+        private val moreMenu = itemView.findViewById<ImageButton>(R.id.ib_post_more_nested)
+        private val commentInput = itemView.findViewById<EditText>(R.id.et_comment_content_nested)
+        private val commentCancel = itemView.findViewById<TextView>(R.id.tv_cancel_nested)
+        private val commentRegister = itemView.findViewById<TextView>(R.id.tv_register_nested)
+        private val constraintSet = itemView.findViewById<ConstraintLayout>(R.id.constraint_view_nested)
+
+        fun bind(item: ResponseComment, position: Int){
             var isContentButtonPressed = false // 댓글 본문이 눌렸는지 안 눌렸는지
 
             if(item.user.profileImgUrl == null){
@@ -76,13 +97,175 @@ class PostNestedCommentAdapter (
                     .circleCrop()
                     .into(commentProfile)
             }
+
+            val popupInflater =
+                context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+            val popupBind =
+                CustomCommentMorePopupBinding.inflate(popupInflater) // 커스텀 팝업 레이아웃 binding inflate
+
+            val popupWindow = PopupWindow(
+                popupBind.root,
+                ViewGroup.LayoutParams.WRAP_CONTENT, // 가로 길이
+                ViewGroup.LayoutParams.WRAP_CONTENT, // 세로 길이
+                true
+            ) // 팝업 윈도우 화면 설정
+
+            moreMenu.setOnClickListener(popupWindow::showAsDropDown) // 더보기 메뉴 클릭 시, 메뉴 view 중심으로 팝업 메뉴 호출
+
+            if (item.user.userId == ResponseExistLogin.baseUserInfo?.userId){ // 내 대댓글이면 수정, 삭제 메뉴가 보이게
+                popupBind.layoutHorizEditComment.visibility = View.VISIBLE
+                popupBind.layoutHorizDeleteComment.visibility = View.VISIBLE
+                popupBind.layoutHorizChatComment.visibility = View.GONE
+                popupBind.layoutHorizBanComment.visibility = View.GONE
+            }else{ // 타 유저 대댓글이면 채팅, 차단 메뉴가 보이게
+                popupBind.layoutHorizEditComment.visibility = View.GONE
+                popupBind.layoutHorizDeleteComment.visibility = View.GONE
+                popupBind.layoutHorizChatComment.visibility = View.VISIBLE
+                popupBind.layoutHorizBanComment.visibility = View.VISIBLE
+            }
+
+            // 수정 뷰에서 취소 버튼 누르면 기존 뷰 원상복구
+            commentCancel.setOnClickListener {
+                changeViewCommentModifyBefore() // 기존 뷰로 폼 변경
+            }
+
+            // 수정 메뉴 클릭 시
+            popupBind.layoutHorizEditComment.setOnClickListener {
+                changeViewCommentModifyAfter(popupWindow) // 수정 뷰로 폼 변경
+            }
+
+            // 삭제 메뉴 클릭 시
+            popupBind.layoutHorizDeleteComment.setOnClickListener {
+                popupWindow.dismiss()
+                // 삭제 다이얼로그 띄우고 요청
+                DialogUtil().MultipleDialog(
+                    context,
+                    "답글을 삭제하시겠습니까?",
+                    "예",
+                    "아니오",
+                    {
+                        // 답글 삭제 요청 함수 시작
+                        processPostCommentDelete(
+                            token,
+                            item.commentId.toLong(),{
+                                if(it){
+                                    Toast.makeText(context,"삭제되었습니다.",Toast.LENGTH_SHORT).show()
+                                    // 대댓글 갱신
+                                    processGetNestedCommentList(
+                                        token,
+                                        commentId,
+                                        0,{
+                                        },{
+                                            binding.tvPostCommentCount.text = (binding.tvPostCommentCount.text.toString().toInt()-data.size + it.size).toString()
+                                            replaceAll(it)
+                                          },{
+                                            it.printStackTrace()
+                                            DialogUtil().SingleDialog(context, "답글 갱신에 문제가 발생하였습니다.", "확인")
+                                        }
+                                    )
+                                }
+                            },{
+                                it.printStackTrace()
+                                DialogUtil().SingleDialog(context, "댓글 삭제에 문제가 발생하였습니다.", "확인")
+                            }
+                        )
+                    },
+                    { popupWindow.dismiss() }).show()
+            }
+
+            // 채팅 메뉴 클릭 시
+            popupBind.layoutHorizChatComment.setOnClickListener {
+                popupWindow.dismiss() // 기능 미구현
+            }
+
+            // 차단 메뉴 클릭 시
+            popupBind.layoutHorizBanComment.setOnClickListener {
+                popupWindow.dismiss() // 기능 미구현
+            }
+
+            // 등록 버튼 누르면 수정 요청
+            commentRegister.setOnClickListener {
+                if(commentInput.text.toString().isNotEmpty()){
+                    processPostCommentEdit(
+                        token,
+                        item.commentId.toLong(),
+                        RequestComment(
+                            commentInput.text.toString(),
+                            Utils.getArrayHashTagWithOutSpace(commentInput.text.toString())
+                        ),{ it ->
+                            if (it){
+                                Toast.makeText(context,"수정이 완료되었습니다.",Toast.LENGTH_SHORT).show()
+                                changeViewCommentModifyBefore() // 원래 댓글 화면으로 뷰 변화 주기
+                                // 대댓글 갱신
+                                processGetNestedCommentList(
+                                    token,
+                                    commentId,
+                                    0,{
+                                    },{
+                                        binding.tvPostCommentCount.text = (binding.tvPostCommentCount.text.toString().toInt()-data.size + it.size).toString()
+                                        replaceAll(it)
+                                    },{
+                                        it.printStackTrace()
+                                        DialogUtil().SingleDialog(context, "답글 갱신에 문제가 발생하였습니다.", "확인")
+                                    }
+                                )
+                            }
+                        },{
+                            it.printStackTrace()
+                            DialogUtil().SingleDialog(context, "답글 수정 요청에 문제가 발생하였습니다.", "확인")
+                        }
+                    )
+                }else{
+                    Toast.makeText(context,"수정할 내용을 입력해주세요!",Toast.LENGTH_SHORT).show()
+                }
+            }
+
             commentNickname.text = item.user.nickname
             commentContent.text = item.content
+            if(item.isLiked) // 내가 좋아요가 누른 상태면
+                commentButtonLike.background = ContextCompat.getDrawable(context,R.drawable.ic_post_like_after)
+            else // 아니라면
+                commentButtonLike.background = ContextCompat.getDrawable(context,R.drawable.ic_post_like)
             commentCountLike.text = item.likeCount.toString()
             commentDate.text = DateUtil().getTimeDiff(item.createdDate)
             setViewHashTag(commentContent, commentContent.text.toString()) // 대댓글 해시태그 강조
 
-            /* 좋아요 구현 예정 */
+            /* 대댓글 좋아요 구현  */
+            commentButtonLike.setOnClickListener {
+                if (!item.isLiked){ // 좋아요가 안 눌렸다면 좋아요 요청
+                    processPostCommentLike(
+                        token,
+                        item.commentId.toLong(),{
+                            if(it){
+                                Log.d("PostNestedCommentAdapter.kt","좋아요 성공")
+                                commentButtonLike.background = ContextCompat.getDrawable(context,R.drawable.ic_post_like_after)
+                                commentCountLike.text = (item.likeCount + 1).toString()
+                                item.isLiked = true
+                                item.likeCount = item.likeCount + 1
+                            }
+                        },{
+                            it.printStackTrace()
+                            DialogUtil().SingleDialog(context, "좋아요 요청에 문제가 발생하였습니다.", "확인")
+                        }
+                    )
+                }else{ // 좋아요가 눌렸다면 좋아요 취소 요청
+                    processPostCommentUnLike(
+                        token,
+                        item.commentId.toLong(),{
+                            if(it){
+                                Log.d("PostNestedCommentAdapter.kt","좋아요 취소 성공")
+                                commentButtonLike.background = ContextCompat.getDrawable(context,R.drawable.ic_post_like)
+                                commentCountLike.text = (item.likeCount - 1).toString()
+                                item.isLiked = false
+                                item.likeCount = item.likeCount - 1
+                            }
+                        },{
+                            it.printStackTrace()
+                            DialogUtil().SingleDialog(context, "좋아요 취소 요청에 문제가 발생하였습니다.", "확인")
+                        }
+                    )
+                }
+            }
 
             /* 더보기 메뉴 구현 */
             commentContent.setOnClickListener { // 클릭 시
@@ -95,10 +278,199 @@ class PostNestedCommentAdapter (
                 }
             }
         }
+
+        /**
+         * @description - 댓글/대댓글 수정 시에 뷰를 바꾸는 메소드 (Before)
+         * @return - None
+         * @author - Tae hyun Park
+         * @since - 2022-09-10
+         */
+        private fun changeViewCommentModifyBefore(){
+            // 기존 뷰 VISIBLE
+            commentNickname.visibility = View.VISIBLE
+            commentContent.visibility = View.VISIBLE
+            commentButtonLike.visibility = View.VISIBLE
+            commentCountLike.visibility = View.VISIBLE
+            commentDate.visibility = View.VISIBLE
+            moreMenu.visibility = View.VISIBLE
+            // 수정 뷰 GONE
+            commentInput.visibility = View.GONE
+            commentCancel.visibility = View.GONE
+            commentRegister.visibility = View.GONE
+        }
+
+        /**
+         * @description - 댓글/대댓글 수정 시에 뷰를 바꾸는 메소드 (After)
+         * @return - None
+         * @author - Tae hyun Park
+         * @since - 2022-09-10
+         */
+        private fun changeViewCommentModifyAfter(popupWindow: PopupWindow){
+            // 수정 뷰를 띄우기 위해 기존 뷰 GONE
+            commentNickname.visibility = View.GONE
+            commentContent.visibility = View.GONE
+            commentButtonLike.visibility = View.GONE
+            commentCountLike.visibility = View.GONE
+            commentDate.visibility = View.GONE
+            moreMenu.visibility = View.GONE
+            // 수정 뷰 VISIBLE
+            commentInput.visibility = View.VISIBLE
+            commentCancel.visibility = View.VISIBLE
+            commentRegister.visibility = View.VISIBLE
+            popupWindow.dismiss()
+            // 수정 전 기존 내용 그대로 보여주기
+            commentInput.setText(commentContent.text.toString())
+        }
     }
 
     inner class LoadingViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         private val progressDialog = itemView.findViewById<ProgressBar>(R.id.progressbar_loading)
+    }
+
+    /**
+     * @description - 게시물의 대댓글 리스트 요청 함수를 호출하는 메소드
+     * @param - token(String) : JWT 토큰
+     * @param - commentId(Long) : 대댓글 리스트를 요청할 게시물 id
+     * @param - lastCommentId(Int) : 가장 최근에 요청한 대댓글 id
+     * @return - None
+     * @author - Tae hyun Park
+     * @since - 2022-09-02
+     */
+    private fun processGetNestedCommentList(
+        token: String,
+        commentId : Long,
+        lastCommentId : Int,
+        init: () -> Unit,
+        last: (List<ResponseComment>) -> Unit,
+        error: (ResponseErrorException) -> Unit
+    ){
+        CoroutineScope(Dispatchers.Main).launch {
+            init() // 초기화 함수 호출
+            val postManager = PostManager() // 커스텀 게시글 객체 생성
+            try {
+                val response = postManager.startGetNestedCommentList(
+                    token,
+                    commentId,
+                    lastCommentId,
+                    ValueUtil.NESTED_COMMENT_SIZE,
+                )
+                last(response) // 받아온 리스트를 바탕으로 후처리 함수 호출
+                Log.d("PostCommentAdapter.kt", "대댓글 리스트 요청 결과 : $response")
+            }catch (e: ResponseErrorException){
+                error(e)
+            }
+        }
+    }
+
+    /**
+     * 해당 제보 게시물의 특정 댓글/대댓글 좋아요를 요청하는 메소드
+     * @param - token(String) : jwt 토큰
+     * @param - commentId(Long) : 좋아요 요청할 댓글/대댓글 id
+     * @author - Tae hyun Park
+     * @since - 2022-09-10
+     */
+    private fun processPostCommentLike(
+        token: String,
+        commentId: Long,
+        last: (Boolean) -> Unit,
+        error: (ResponseErrorException) -> Unit
+    ){
+        CoroutineScope(Dispatchers.Main).launch {
+            val postManager = PostManager() // 커스텀 게시글 객체 생성
+            try {
+                val response = postManager.startPostCommentLike(
+                    token,
+                    commentId
+                )
+                last(response) // 받아온 리스트를 바탕으로 후처리 함수 호출
+            }catch (e: ResponseErrorException){
+                error(e)
+            }
+        }
+    }
+
+    /**
+     * 해당 제보 게시물의 특정 댓글/대댓글 좋아요 취소를 요청하는 메소드
+     * @param - token(String) : jwt 토큰
+     * @param - commentId(Long) : 좋아요 취소 요청할 댓글/대댓글 id
+     * @author - Tae hyun Park
+     * @since - 2022-09-10
+     */
+    private fun processPostCommentUnLike(
+        token: String,
+        commentId: Long,
+        last: (Boolean) -> Unit,
+        error: (ResponseErrorException) -> Unit
+    ){
+        CoroutineScope(Dispatchers.Main).launch {
+            val postManager = PostManager() // 커스텀 게시글 객체 생성
+            try {
+                val response = postManager.startPostCommentUnLike(
+                    token,
+                    commentId
+                )
+                last(response) // 받아온 리스트를 바탕으로 후처리 함수 호출
+            }catch (e: ResponseErrorException){
+                error(e)
+            }
+        }
+    }
+
+    /**
+     * 해당 제보 게시물의 특정 댓글/대댓글 수정을 요청하는 메소드
+     * @param - token(String) : jwt 토큰
+     * @param - commentId(Long) : 수정 요청할 댓글/대댓글 id
+     * @param - commentInfo(RequestComment) : 수정할 댓글 dto
+     * @author - Tae hyun Park
+     * @since - 2022-09-10
+     */
+    private fun processPostCommentEdit(
+        token: String,
+        commentId: Long,
+        commentInfo: RequestComment,
+        last: (Boolean) -> Unit,
+        error: (ResponseErrorException) -> Unit
+    ){
+        CoroutineScope(Dispatchers.Main).launch {
+            val postManager = PostManager() // 커스텀 게시글 객체 생성
+            try {
+                val response = postManager.startPostCommentEdit(
+                    token,
+                    commentId,
+                    commentInfo
+                )
+                last(response) // 받아온 리스트를 바탕으로 후처리 함수 호출
+            }catch (e: ResponseErrorException){
+                error(e)
+            }
+        }
+    }
+
+    /**
+     * 해당 제보 게시물의 특정 댓글/대댓글 삭제를 요청하는 메소드
+     * @param - token(String) : jwt 토큰
+     * @param - commentId(Long) : 삭제 요청할 댓글/대댓글 id
+     * @author - Tae hyun Park
+     * @since - 2022-09-10
+     */
+    private fun processPostCommentDelete(
+        token: String,
+        commentId: Long,
+        last: (Boolean) -> Unit,
+        error: (ResponseErrorException) -> Unit
+    ){
+        CoroutineScope(Dispatchers.Main).launch {
+            val postManager = PostManager() // 커스텀 게시글 객체 생성
+            try {
+                val response = postManager.startPostCommentDelete(
+                    token,
+                    commentId
+                )
+                last(response) // 받아온 리스트를 바탕으로 후처리 함수 호출
+            }catch (e: ResponseErrorException){
+                error(e)
+            }
+        }
     }
 
     /**

--- a/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseComment.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/model/response/ResponseComment.kt
@@ -5,9 +5,9 @@ import com.google.gson.annotations.SerializedName
 data class ResponseComment(
     @SerializedName("commentId") val commentId: Int,
     @SerializedName("content") val content: String,
-    @SerializedName("likeCount") val likeCount: Int,
+    @SerializedName("likeCount") var likeCount: Int,
     @SerializedName("replyCount") val replyCount: Int,
     @SerializedName("user") val user: ResponseCommentUser,
-    @SerializedName("isLiked") val isLiked: Boolean,
+    @SerializedName("isLiked") var isLiked: Boolean,
     @SerializedName("createdDate") val createdDate: String
 )

--- a/Breaking/app/src/main/java/com/dope/breaking/post/PostManager.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/post/PostManager.kt
@@ -658,6 +658,133 @@ class PostManager {
     }
 
     /**
+     * 게시물 댓글/대댓글 좋아요 요청을 보내기 위한 메소드
+     * @param token(String) : jwt token 값
+     * @param commentId(Long) : 좋아요 하고자 하는 댓글/대댓글 id
+     * @author Tae hyun Park
+     * @since 2022-09-10
+     */
+    @Throws(ResponseErrorException::class)
+    suspend fun startPostCommentLike(
+        token: String,
+        commentId: Long,
+    ): Boolean {
+        // Retrofit 서비스 객체 생성
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+
+        // 게시글 댓글/대댓글 좋아요 요청
+        val response = service.requestPostCommentLike(
+            token,
+            commentId,
+        )
+
+        // 요청이 성공적이라면
+        if (response.isSuccessful) {
+            Log.d(TAG,"요청 성공")
+            return response.code() in 200..299
+        } else {
+            Log.d(TAG, "요청 실패 : ${response.errorBody()?.string()}")
+            throw ResponseErrorException("요청에 실패하였습니다. error: ${response.errorBody()?.string()}")
+        }
+    }
+
+    /**
+     * 게시물 댓글/대댓글 좋아요 취소 요청을 보내기 위한 메소드
+     * @param token(String) : jwt token 값
+     * @param commentId(Long) : 좋아요 취소하고자 하는 댓글/대댓글 id
+     * @author Tae hyun Park
+     * @since 2022-09-10
+     */
+    @Throws(ResponseErrorException::class)
+    suspend fun startPostCommentUnLike(
+        token: String,
+        commentId: Long,
+    ): Boolean {
+        // Retrofit 서비스 객체 생성
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+
+        // 게시글 댓글/대댓글 좋아요 취소 요청
+        val response = service.requestPostCommentUnLike(
+            token,
+            commentId,
+        )
+
+        // 요청이 성공적이라면
+        if (response.isSuccessful) {
+            Log.d(TAG,"요청 성공")
+            return response.code() in 200..299
+        } else {
+            Log.d(TAG, "요청 실패 : ${response.errorBody()?.string()}")
+            throw ResponseErrorException("요청에 실패하였습니다. error: ${response.errorBody()?.string()}")
+        }
+    }
+
+    /**
+     * 게시물 댓글/대댓글 수정 요청을 보내기 위한 메소드
+     * @param token(String) : jwt token 값
+     * @param commentId(Long) : 수정하고자 하는 댓글/대댓글 id
+     * @param commentInfo(RequestComment) : 수정 정보
+     * @author Tae hyun Park
+     * @since 2022-09-10
+     */
+    @Throws(ResponseErrorException::class)
+    suspend fun startPostCommentEdit(
+        token: String,
+        commentId: Long,
+        commentInfo: RequestComment
+    ): Boolean {
+        // Retrofit 서비스 객체 생성
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+
+        // 게시글 댓글/대댓글 수정 요청
+        val response = service.requestPostCommentEdit(
+            token,
+            commentId,
+            commentInfo
+        )
+
+        // 요청이 성공적이라면
+        if (response.isSuccessful) {
+            Log.d(TAG,"요청 성공")
+            return response.code() in 200..299
+        } else {
+            Log.d(TAG, "요청 실패 : ${response.errorBody()?.string()}")
+            throw ResponseErrorException("요청에 실패하였습니다. error: ${response.errorBody()?.string()}")
+        }
+    }
+
+    /**
+     * 게시물 댓글/대댓글 삭제 요청을 보내기 위한 메소드
+     * @param token(String) : jwt token 값
+     * @param commentId(Long) : 삭제하고자 하는 댓글/대댓글 id
+     * @author Tae hyun Park
+     * @since 2022-09-10
+     */
+    @Throws(ResponseErrorException::class)
+    suspend fun startPostCommentDelete(
+        token: String,
+        commentId: Long,
+    ): Boolean {
+        // Retrofit 서비스 객체 생성
+        val service = RetrofitManager.retrofit.create(RetrofitService::class.java)
+
+        // 게시글 댓글/대댓글 삭제 요청
+        val response = service.requestPostCommentDelete(
+            token,
+            commentId
+        )
+
+        // 요청이 성공적이라면
+        if (response.isSuccessful) {
+            Log.d(TAG,"요청 성공")
+            return response.code() in 200..299
+        } else {
+            Log.d(TAG, "요청 실패 : ${response.errorBody()?.string()}")
+            throw ResponseErrorException("요청에 실패하였습니다. error: ${response.errorBody()?.string()}")
+        }
+    }
+
+    /**
      * 메인 피드 요청을 통해 리스트를 가져옴 (필터 & 정렬 옵션 포함)
      * @param lastPostId(Int): 마지막으로 요청한 마지막 게시글 id (최초 요청 시, 0 또는 null)
      * @param contentSize(Int): 요청할 게시글 개수(현재 10개)

--- a/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/retrofit/RetrofitService.kt
@@ -303,6 +303,56 @@ interface RetrofitService {
     ): Response<Unit>
 
     /**
+     * 해당 제보 게시물의 특정 댓글/대댓글 좋아요를 요청하는 메소드
+     * @param - token(String) : jwt 토큰
+     * @Path - commentId(Long) : 좋아요 요청할 댓글/대댓글 id
+     * @author - Tae hyun Park
+     */
+    @POST("post/comment/{commentId}/like")
+    suspend fun requestPostCommentLike(
+        @Header("authorization") token: String,
+        @Path("commentId") commentId: Long
+    ): Response<Unit>
+
+    /**
+     * 해당 제보 게시물의 특정 댓글/대댓글 좋아요 취소를 요청하는 메소드
+     * @param - token(String) : jwt 토큰
+     * @Path - commentId(Long) : 좋아요 취소 요청할 댓글/대댓글 id
+     * @author - Tae hyun Park
+     */
+    @DELETE("post/comment/{commentId}/like")
+    suspend fun requestPostCommentUnLike(
+        @Header("authorization") token: String,
+        @Path("commentId") commentId: Long
+    ): Response<Unit>
+
+    /**
+     * 제보 게시물의 댓글/대댓글 수정을 요청하는 메소드
+     * @param - token(String) : jwt 토큰
+     * @Path - commentId(Long) : 수정을 요청할 댓글/대댓글 id
+     * @Body - comment(RequestComment) : 수정할 댓글/대댓글 정보
+     * @author - Tae hyun Park
+     */
+    @PUT("post/comment/{commentId}")
+    suspend fun requestPostCommentEdit(
+        @Header("authorization") token: String,
+        @Path("commentId") commentId: Long,
+        @Body comment: RequestComment
+    ): Response<Unit>
+
+    /**
+     * 제보 게시물의 댓글/대댓글 삭제를 요청하는 메소드
+     * @param - token(String) : jwt 토큰
+     * @Path - commentId(Long) : 삭제를 요청할 댓글/대댓글 id
+     * @author - Tae hyun Park
+     */
+    @DELETE("post/comment/{commentId}")
+    suspend fun requestPostCommentDelete(
+        @Header("authorization") token: String,
+        @Path("commentId") commentId: Long,
+    ): Response<Unit>
+
+    /**
      * 구글 로그인 토큰 검증 요청 메소드
      * @param userAgent: 안드로이드 플랫폼 user-agent 헤더 값
      * @request RequestGoogleToken

--- a/Breaking/app/src/main/java/com/dope/breaking/util/ValueUtil.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/util/ValueUtil.kt
@@ -24,7 +24,7 @@ class ValueUtil {
         const val VIEW_TYPE_LOADING = 1 // 로딩 아이템에 대한 레이아웃 view type
         const val USER_FEED_SIZE = 10 // 유저 페이지 피드 요청마다 가져올 게시글 개수
         const val TRANSACTION_SIZE = 25 // 입출금 내역 리스트 가져올 개수
-        const val COMMENT_SIZE = 3 // 댓글 요청마다 가져올 댓글 개수
+        const val COMMENT_SIZE = 6 // 댓글 요청마다 가져올 댓글 개수
         const val NESTED_COMMENT_SIZE = 10 // 대댓글 요청마다 가져올 대댓글 개수
         const val LIKE_SIZE = 10 // 좋아요 리스트 요청마다 가져올 유저 개수
         const val PURCHASE_SIZE = 10 // 좋아요 리스트 요청마다 가져올 유저 개수

--- a/Breaking/app/src/main/res/layout/activity_post_detail.xml
+++ b/Breaking/app/src/main/res/layout/activity_post_detail.xml
@@ -384,6 +384,7 @@
                     android:ellipsize="end"
                     android:text=""
                     android:lines="10"
+                    android:maxLines="10"
                     android:scrollbars="vertical"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"

--- a/Breaking/app/src/main/res/layout/custom_comment_more_popup.xml
+++ b/Breaking/app/src/main/res/layout/custom_comment_more_popup.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/popup_menu_background"
+    android:padding="8dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <LinearLayout
+            android:id="@+id/layout_horiz_edit_comment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="7dp"
+            android:background="@drawable/none_background_click_background"
+            android:clickable="true"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/layout_horiz_delete_comment"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_baseline_edit_24" />
+
+            <TextView
+                android:id="@+id/test"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:gravity="start"
+                android:paddingStart="20dp"
+                android:paddingEnd="0dp"
+                android:text="수정"
+                android:textColor="@color/black"
+                android:textSize="12sp" />
+
+            <View
+                android:layout_width="20dp"
+                android:layout_height="match_parent" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/layout_horiz_delete_comment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="7dp"
+            android:background="@drawable/none_background_click_background"
+            android:clickable="true"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@id/layout_horiz_chat_comment"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layout_horiz_edit_comment"
+            >
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_baseline_delete_24" />
+
+            <TextView
+                android:id="@+id/test1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:gravity="start"
+                android:paddingStart="20dp"
+                android:paddingEnd="0dp"
+                android:text="삭제"
+                android:textColor="@color/black"
+                android:textSize="12sp" />
+
+            <View
+                android:layout_width="20dp"
+                android:layout_height="match_parent" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/layout_horiz_chat_comment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="7dp"
+            android:background="@drawable/none_background_click_background"
+            android:clickable="true"
+            android:orientation="horizontal"
+            android:visibility="visible"
+            app:layout_constraintBottom_toTopOf="@id/layout_horiz_ban_comment"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layout_horiz_delete_comment">
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_baseline_chat_24" />
+
+            <TextView
+                android:id="@+id/tv_popup_chat"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:gravity="start"
+                android:paddingStart="20dp"
+                android:paddingEnd="0dp"
+                android:text="채팅"
+                android:textColor="@color/black"
+                android:textSize="12sp" />
+
+            <View
+                android:layout_width="20dp"
+                android:layout_height="match_parent" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/layout_horiz_ban_comment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/none_background_click_background"
+            android:clickable="true"
+            android:orientation="horizontal"
+            android:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layout_horiz_chat_comment"
+            >
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_baseline_do_not_disturb_24" />
+
+            <TextView
+                android:id="@+id/tv_popup_ban"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:gravity="start"
+                android:paddingStart="20dp"
+                android:paddingEnd="0dp"
+                android:text="차단"
+                android:textColor="@color/black"
+                android:textSize="12sp" />
+
+            <View
+                android:layout_width="20dp"
+                android:layout_height="match_parent" />
+        </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/Breaking/app/src/main/res/layout/item_comment_list.xml
+++ b/Breaking/app/src/main/res/layout/item_comment_list.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/constraint_view"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android"
@@ -29,6 +30,7 @@
         android:text="만두피"
         android:textColor="@color/black"
         android:textSize="14.5sp"
+        android:visibility="visible"
         app:layout_constraintHorizontal_bias="0.075"
         app:layout_constraintLeft_toRightOf="@+id/iv_comment_profile"
         app:layout_constraintRight_toRightOf="parent"
@@ -40,6 +42,7 @@
         android:layout_height="wrap_content"
         android:layout_marginLeft="5dp"
         android:textSize="12sp"
+        android:visibility="visible"
         app:layout_constraintLeft_toRightOf="@+id/tv_comment_nickname"
         app:layout_constraintTop_toTopOf="@+id/tv_comment_nickname"
         app:layout_constraintBottom_toBottomOf="@+id/tv_comment_nickname"/>
@@ -50,6 +53,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="5dp"
         android:layout_marginRight="10dp"
+        android:visibility="visible"
         android:ellipsize="end"
         android:maxLines="2"
         android:text="코로나 사태가 아직 진정이 되지 않았는데, 코로나 사태가 아직 진정이 되지 않았는데, 코로나 사태가 아직 진정이 되지 않았는데, 코로나 사태가 아직 진정이 되지 않았는데, 코로나 사태가 아직 진정이 되지 않았는데, 코로나 사태가 아직 진정이 되지 않았는데, 코로나 사태가 아직 진정이 되지 않았는데, 코로나 사태가 아직 진정이 되지 않았는데, 다시 확산이 될까봐 무섭네요 ㅠㅠ"
@@ -60,6 +64,22 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tv_comment_nickname" />
 
+    <EditText
+        android:id="@+id/et_comment_content"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:layout_marginRight="10dp"
+        android:text=""
+        android:textColor="@color/black"
+        android:textSize="12sp"
+        android:visibility="gone"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintWidth_percent="0.7"
+        app:layout_constraintLeft_toRightOf="@+id/iv_comment_profile"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/iv_comment_profile" />
+
     <ImageButton
         android:id="@+id/ib_post_like"
         android:layout_width="0dp"
@@ -68,6 +88,7 @@
         app:layout_constraintDimensionRatio="1:1"
         android:layout_marginTop="5dp"
         android:background="@drawable/ic_post_like"
+        android:visibility="visible"
         app:layout_constraintHorizontal_bias="0"
         app:layout_constraintLeft_toLeftOf="@+id/tv_comment_content"
         app:layout_constraintRight_toRightOf="parent"
@@ -80,6 +101,7 @@
         android:text="9,999"
         android:textColor="@color/black"
         android:textSize="13sp"
+        android:visibility="visible"
         app:layout_constraintBottom_toBottomOf="@+id/ib_post_like"
         app:layout_constraintHorizontal_bias="0.03"
         app:layout_constraintLeft_toRightOf="@+id/ib_post_like"
@@ -93,6 +115,7 @@
         android:text="답글"
         android:textColor="@color/black"
         android:textSize="13sp"
+        android:visibility="visible"
         app:layout_constraintBottom_toBottomOf="@+id/ib_post_like"
         app:layout_constraintHorizontal_bias="0.13"
         app:layout_constraintLeft_toRightOf="@+id/tv_post_like_count"
@@ -100,9 +123,10 @@
         app:layout_constraintTop_toTopOf="@+id/ib_post_like" />
 
     <ImageButton
-        android:id="@+id/ib_post_more"
+        android:id="@+id/ib_post_more_comment"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:visibility="visible"
         android:background="@drawable/ic_baseline_more_horiz_24"
         app:layout_constraintBottom_toBottomOf="@id/ib_post_like"
         app:layout_constraintHorizontal_bias="0.85"
@@ -119,11 +143,43 @@
         android:text="답글 더보기"
         android:textColor="@color/breaking_color"
         android:textSize="12sp"
+        android:visibility="visible"
         app:layout_constraintHorizontal_bias="0"
         app:layout_constraintLeft_toLeftOf="@+id/ib_post_like"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/ib_post_like"
         app:layout_constraintVertical_bias="0.4" />
+
+    <TextView
+        android:id="@+id/tv_cancel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="취소"
+        android:textSize="12sp"
+        android:textColor="@color/breaking_color"
+        android:visibility="gone"
+        android:layout_marginTop="5dp"
+        android:layout_marginRight="15dp"
+        app:layout_constraintHorizontal_bias="0.95"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintTop_toBottomOf="@+id/et_comment_content"
+        app:layout_constraintBottom_toTopOf="@+id/rv_nested_comment_list"
+        app:layout_constraintLeft_toLeftOf="@+id/et_comment_content"
+        app:layout_constraintRight_toLeftOf="@+id/tv_register" />
+
+    <TextView
+        android:id="@+id/tv_register"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="등록"
+        android:textSize="12sp"
+        android:textColor="@color/breaking_color"
+        android:visibility="gone"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintTop_toTopOf="@+id/tv_cancel"
+        app:layout_constraintBottom_toBottomOf="@+id/tv_cancel"
+        app:layout_constraintLeft_toRightOf="@+id/tv_cancel"
+        app:layout_constraintRight_toRightOf="@+id/et_comment_content" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_nested_comment_list"
@@ -131,7 +187,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
         android:orientation="vertical"
-        android:visibility="visible"
+        android:visibility="gone"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintLeft_toLeftOf="parent"

--- a/Breaking/app/src/main/res/layout/item_nested_comment_list.xml
+++ b/Breaking/app/src/main/res/layout/item_nested_comment_list.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/constraint_view_nested"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -30,6 +31,7 @@
         android:text="만두피"
         android:textColor="@color/black"
         android:textSize="13.5sp"
+        android:visibility="visible"
         app:layout_constraintHorizontal_bias="0.06"
         app:layout_constraintLeft_toRightOf="@+id/iv_comment_profile_nested"
         app:layout_constraintRight_toRightOf="parent"
@@ -41,6 +43,7 @@
         android:layout_height="wrap_content"
         android:layout_marginLeft="5dp"
         android:textSize="10sp"
+        android:visibility="visible"
         app:layout_constraintLeft_toRightOf="@+id/tv_comment_nickname_nested"
         app:layout_constraintTop_toTopOf="@+id/tv_comment_nickname_nested"
         app:layout_constraintBottom_toBottomOf="@+id/tv_comment_nickname_nested"/>
@@ -56,11 +59,28 @@
         android:textSize="11.5sp"
         android:ellipsize="end"
         android:maxLines="2"
+        android:visibility="visible"
         app:layout_constraintWidth_percent="0.57"
         app:layout_constraintHorizontal_bias="0"
         app:layout_constraintLeft_toLeftOf="@+id/tv_comment_nickname_nested"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tv_comment_nickname_nested" />
+
+    <EditText
+        android:id="@+id/et_comment_content_nested"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:layout_marginRight="10dp"
+        android:text=""
+        android:textColor="@color/black"
+        android:textSize="12sp"
+        android:visibility="gone"
+        app:layout_constraintHorizontal_bias="0.55"
+        app:layout_constraintWidth_percent="0.65"
+        app:layout_constraintLeft_toRightOf="@+id/iv_comment_profile_nested"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/iv_comment_profile_nested" />
 
     <ImageButton
         android:id="@+id/ib_post_like_nested"
@@ -69,6 +89,7 @@
         app:layout_constraintWidth_percent="0.04"
         android:layout_marginTop="5dp"
         android:background="@drawable/ic_post_like"
+        android:visibility="visible"
         app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintHorizontal_bias="0"
         app:layout_constraintLeft_toLeftOf="@+id/tv_comment_content_nested"
@@ -83,6 +104,7 @@
         android:text="9,999"
         android:textColor="@color/black"
         android:textSize="12sp"
+        android:visibility="visible"
         app:layout_constraintHorizontal_bias="0.03"
         app:layout_constraintTop_toTopOf="@+id/ib_post_like_nested"
         app:layout_constraintBottom_toBottomOf="@+id/ib_post_like_nested"
@@ -90,26 +112,45 @@
         app:layout_constraintRight_toRightOf="parent"/>
 
     <TextView
-        android:id="@+id/tv_post_reply_nested"
+        android:id="@+id/tv_cancel_nested"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="답글"
-        android:textColor="@color/black"
+        android:text="취소"
+        android:textSize="12sp"
+        android:textColor="@color/breaking_color"
         android:visibility="gone"
-        app:layout_constraintHorizontal_bias="0.13"
-        app:layout_constraintTop_toTopOf="@+id/ib_post_like_nested"
-        app:layout_constraintBottom_toBottomOf="@+id/ib_post_like_nested"
-        app:layout_constraintLeft_toRightOf="@+id/tv_post_like_count_nested"
-        app:layout_constraintRight_toRightOf="parent"/>
+        android:layout_marginTop="5dp"
+        android:layout_marginRight="15dp"
+        app:layout_constraintHorizontal_bias="0.95"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintTop_toBottomOf="@+id/et_comment_content_nested"
+        app:layout_constraintLeft_toLeftOf="@+id/et_comment_content_nested"
+        app:layout_constraintRight_toLeftOf="@+id/tv_register_nested" />
+
+    <TextView
+        android:id="@+id/tv_register_nested"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="등록"
+        android:textSize="12sp"
+        android:textColor="@color/breaking_color"
+        android:visibility="gone"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintTop_toTopOf="@+id/tv_cancel_nested"
+        app:layout_constraintBottom_toBottomOf="@+id/tv_cancel_nested"
+        app:layout_constraintLeft_toRightOf="@+id/tv_cancel_nested"
+        app:layout_constraintRight_toRightOf="@+id/et_comment_content_nested" />
+
 
     <ImageButton
         android:id="@+id/ib_post_more_nested"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="@drawable/ic_baseline_more_horiz_24"
+        android:visibility="visible"
         app:layout_constraintTop_toTopOf="@+id/ib_post_like_nested"
         app:layout_constraintBottom_toBottomOf="@id/ib_post_like_nested"
-        app:layout_constraintHorizontal_bias="0.85"
-        app:layout_constraintLeft_toRightOf="@id/tv_post_reply_nested"
+        app:layout_constraintHorizontal_bias="0.87"
+        app:layout_constraintLeft_toRightOf="@id/tv_post_like_count_nested"
         app:layout_constraintRight_toRightOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #121 

## 예상 리뷰 시간
20-min

## 추가 또는 변경사항
- 게시글 세부 조회 댓글/대댓글 좋아요, 좋아요 취소를 구현했습니다.

- 게시글 세부 조회 댓글/대댓글 수정을 구현했습니다.
  - 댓글 수정 시 데이터 갱신의 범주는 전체 댓글과 내가 수정하고 있는 댓글의 대댓글이 자연스럽게 갱신되도록 했습니다. 만약 누군가 내가 수정하고 있는 사이에 댓글이나 대댓글을 작성한다면 수정 이후 댓글 카운트, 그리고 뷰가 추가되어서 보여집니다. 리사이클러뷰의 어댑터, 데이터의 `clear()`나 `addAll()`, `removeAll()` 그리고 `notifyDataSetChanged()`등을 활용하여 리스트를 갱신 처리 했습니다.
  - 대댓글 수정 시에는 현재 내가 수정하고 있는 대댓글 중간에 누가 대댓글을 작성한다면 자연스럽게 업데이트 되도록 갱신 처리하였습니다. 원리는 위와 같습니다.
  
- 게시글 세부 조회 댓글/대댓글 삭제를 구현했습니다.
  - 댓글/대댓글 삭제 시에도 마찬가지로 리스트 갱신이 잘 이루어지는 것을 확인했고, 댓글 카운트와 싱크를 맞추었습니다.

- 게시글 세부 조회 댓글/대댓글 수정 View를 만들었습니다.
  - 수정 메뉴를 누르게 되면 기존 댓글 폼에서 수정 폼으로 변하도록 했습니다. 취소를 누를 시 다시 기존 폼으로 돌아갑니다.   

- 댓글/대댓글이 본인인 경우 수정, 삭제 팝업 메뉴를, 다른 유저인 경우 채팅, 차단 팝업 메뉴를 띄우도록 했습니다. 

- 게시글 세부 조회에서 대댓글의 경우 리사이클러뷰 데코레이션을 제거하였습니다. (UI적으로 보기 더 자연스러운 이유입니다. 인스타그램도 대댓글의 경우에는 따로 선 디자인이 없더군요. 괜찮은 방법 같습니다)

## 스크린샷
- 댓글/대댓글 팝업 메뉴 화면
<img src="https://user-images.githubusercontent.com/31824443/189496096-4c46d707-0dca-460d-b597-a124aa38f4f6.png" width="30%" height="30%"/>

- 댓글/대댓글 수정 화면
<img src="https://user-images.githubusercontent.com/31824443/189496127-cbfb3c3a-30c7-4b4e-a161-81823fc99794.png" width="30%" height="30%"/>
<img src="https://user-images.githubusercontent.com/31824443/189496149-fc45cc31-64c8-4d45-9e5e-f29cc61ae6fc.png" width="30%" height="30%"/>

- 댓글/대댓글 삭제 화면
<img src="https://user-images.githubusercontent.com/31824443/189496137-4ed5f4f2-d1b0-44eb-bc2f-c1aa20fcabd2.png" width="30%" height="30%"/>

## 기타
- 수정 즉시 내가 수정하고 있는 댓글의 답글 말고 다른 댓글의 답글까지 완벽히 갱신하고 싶었으나, 어댑터, 리사이클러뷰의 지식 부족으로 인해 같은 타이밍에 아이템의 리사이클러뷰 데이터를 각각 다르게 갱신하기가 쉽지 않았습니다. 이는 계속 고민하며 해결해나가야 할 문제입니다. 갱신 처리의 범주와 방식에 대해 고민하느라 많은 시간을 썼던 것 같습니다. 또한, 내부 대댓글(답글) 수정 시에는 외부 댓글도 함께 갱신하고 싶었는데 이 역시 한계였습니다. 댓글/대댓글의 구조가 adapter안에 adapter가 있는 구조인데, 내부 어댑터를 호출한 바깥 어댑터의 데이터를 제어하는 것이 어려웠고, 많은 고민을 했지만 우선 대댓글은 대댓글끼리만 갱신되도록 처리했습니다.

- 현재와 같은 방식으로 해도 불편하거나, 기능 사용이 불가한 것은 아닙니다. 하지만 실시간 갱신까지는 아니더라도 어느정도 싱크가 완벽한 갱신을 하고 싶었기 때문에 많은 생각을 했던 것 같습니다. 사용성 증대를 위해서는 위에서 말한 고민들도 해결해나간다면 정말 좋을 것 같습니다. 

- 프론트 팀의 런칭 웹 페이지와 많은 비교를 하면서 이 부분은 어떻게 처리했을까에 대한 예외 상황, 안드로이드는 어떻게 처리하는 것이 좋을 지에 대해 고민하면서 끊임없는 테스팅을 했습니다. 그 결과 괜찮은 예외/테스트 케이스에 대해 많이 생각할 수 있게 되었고, 제가 발목이 많이 붙잡혀서 시간이 끌리기도 했습니다..ㅋㅋ 웹에서는 어떻게 처리하는지 궁금한 점도 한 둘이 아니었지만.. 그러면서 나름 기능 개발하는 데에 좋은 영감을 많이 얻었습니다.
 
  