### PR TITLE
refactor: fix split user tab according to current user

### DIFF
--- a/Breaking/app/src/main/AndroidManifest.xml
+++ b/Breaking/app/src/main/AndroidManifest.xml
@@ -14,8 +14,6 @@
     <application
         android:name=".GlobalApplication"
         android:allowBackup="false"
-        android:hardwareAccelerated="false"
-        android:largeHeap="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="false"
         android:hardwareAccelerated="false"

--- a/Breaking/app/src/main/java/com/dope/breaking/FeedSearchActivity.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/FeedSearchActivity.kt
@@ -1,6 +1,7 @@
 package com.dope.breaking
 
 import android.content.Context
+import android.content.Intent
 import android.graphics.Typeface
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
@@ -19,6 +20,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.dope.breaking.adapter.FeedAdapter
 import com.dope.breaking.adapter.UserSearchAdapter
+import com.dope.breaking.board.PostDetailActivity
 import com.dope.breaking.databinding.ActivityFeedSearchBinding
 import com.dope.breaking.exception.ResponseErrorException
 import com.dope.breaking.model.response.ResponseMainFeed
@@ -53,6 +55,12 @@ class FeedSearchActivity : AppCompatActivity() {
         binding = ActivityFeedSearchBinding.inflate(layoutInflater)
 
         feedAdapter = FeedAdapter(this, feedList) // 피드 어댑터
+        // 피드 아이템 클릭 이벤트
+        feedAdapter.setItemListClickListener(object : FeedAdapter.OnItemClickListener {
+            override fun onClick(v: View, position: Int) {
+                moveToPostDetailPage(position) // 세부 조회 페이지로 이동
+            }
+        })
         userAdapter = UserSearchAdapter(this, userList) // 유저 검색 어댑터
 
         // 리사이클러뷰 divider 지정
@@ -598,5 +606,17 @@ class FeedSearchActivity : AppCompatActivity() {
         )
 
         binding.tvAnnounceSearchUser.text = spannableString
+    }
+
+    /**
+     * 어댑터에서 아이템 리스트를 클릭했을 때, 해당 postId를 받아와 세부 조회 액티비티로 넘겨주는 함수
+     * @param position(Int): 현재 리스트의 인덱스
+     * @author Seunggun Sin
+     * @since 2022-09-12
+     */
+    private fun moveToPostDetailPage(position: Int) {
+        val intent = Intent(this, PostDetailActivity::class.java)
+        intent.putExtra("postId", feedList[position]!!.postId)
+        startActivity(intent)
     }
 }

--- a/Breaking/app/src/main/java/com/dope/breaking/adapter/UserViewPagerAdapter.kt
+++ b/Breaking/app/src/main/java/com/dope/breaking/adapter/UserViewPagerAdapter.kt
@@ -8,6 +8,7 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.dope.breaking.fragment.user_tab.BookmarkedTabFragment
 import com.dope.breaking.fragment.user_tab.PostTabFragment
 import com.dope.breaking.fragment.user_tab.PurchasedTabFragment
+import com.dope.breaking.model.response.ResponseExistLogin
 
 private const val NUM_TABS = 3 // 탭의 개수
 
@@ -21,30 +22,36 @@ class UserViewPagerAdapter(
 ) : FragmentStateAdapter(fragmentManager, lifecycle) {
 
     override fun getItemCount(): Int {
-        return NUM_TABS
+        return if (ResponseExistLogin.baseUserInfo != null && ResponseExistLogin.baseUserInfo!!.userId == userId) NUM_TABS else 1
     }
 
     override fun createFragment(position: Int): Fragment {
         val bundle = Bundle()
         bundle.putLong("userId", userId)
-        when (position) {
-            0 -> {
-                val fragment = PostTabFragment()
-                fragment.arguments = bundle
-                return fragment
-            } // 0번째 인덱스일 때 "작성 제보 Fragment"}
-            1 -> {
-                val fragment = PurchasedTabFragment()
-                fragment.arguments = bundle
-                return fragment
-            } // 1번째 인덱스일 때 "구매 제보 Fragment"
-            2 -> {
-                val fragment = BookmarkedTabFragment()
-                fragment.arguments = bundle
-                return fragment
-            } // 2번째 인덱스일 때 "북마크 제보 Fragment"
+        // 현재 유저가 본인이라면 모든 탭 다 보여주기
+        if (ResponseExistLogin.baseUserInfo != null && ResponseExistLogin.baseUserInfo!!.userId == userId) {
+            when (position) {
+                0 -> {
+                    val fragment = PostTabFragment()
+                    fragment.arguments = bundle
+                    return fragment
+                } // 0번째 인덱스일 때 "작성 제보 Fragment"}
+                1 -> {
+                    val fragment = PurchasedTabFragment()
+                    fragment.arguments = bundle
+                    return fragment
+                } // 1번째 인덱스일 때 "구매 제보 Fragment"
+                2 -> {
+                    val fragment = BookmarkedTabFragment()
+                    fragment.arguments = bundle
+                    return fragment
+                } // 2번째 인덱스일 때 "북마크 제보 Fragment"
+            }
         }
-        return PostTabFragment() // default 로 "작성 제보 Fragment"
+        // 다른 유저의 경우 작성한 제보 탭만 보여주기
+        val fragment = PostTabFragment()
+        fragment.arguments = bundle
+        return fragment // default 로 "작성 제보 Fragment"
     }
 
 }

--- a/Breaking/app/src/main/res/layout/fragment_bookmarked_tab.xml
+++ b/Breaking/app/src/main/res/layout/fragment_bookmarked_tab.xml
@@ -7,11 +7,19 @@
     android:orientation="vertical"
     tools:context=".fragment.user_tab.BookmarkedTabFragment">
 
+    <TextView
+        android:id="@+id/tv_empty_text"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="@string/no_bookmarked"
+        android:visibility="gone" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:padding="7dp">
+        android:padding="6dp">
 
         <TextView
             android:id="@+id/tv_option_all"
@@ -19,7 +27,7 @@
             android:layout_height="wrap_content"
             android:text="@string/entire_option"
             android:textColor="@color/breaking_bottom_clicked_color"
-            android:textSize="11sp"
+            android:textSize="11.5sp"
             android:textStyle="bold"
             app:layout_constraintHorizontal_bias="0.02"
             app:layout_constraintLeft_toLeftOf="parent"
@@ -32,7 +40,7 @@
             android:layout_height="wrap_content"
             android:text="@string/sold_option"
             android:textColor="@color/black"
-            android:textSize="11sp"
+            android:textSize="11.5sp"
             app:layout_constraintHorizontal_bias="0.17"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
@@ -44,7 +52,7 @@
             android:layout_height="wrap_content"
             android:text="@string/unsold_option"
             android:textColor="@color/black"
-            android:textSize="11sp"
+            android:textSize="11.5sp"
             app:layout_constraintHorizontal_bias="0.37"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
@@ -52,13 +60,7 @@
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-    <TextView
-        android:visibility="gone"
-        android:id="@+id/tv_empty_text"
-        android:gravity="center"
-        android:text="@string/no_bookmarked"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rcv_user_bookmarked"
         android:layout_width="match_parent"

--- a/Breaking/app/src/main/res/layout/fragment_navi_user.xml
+++ b/Breaking/app/src/main/res/layout/fragment_navi_user.xml
@@ -25,9 +25,9 @@
             android:layout_height="0dp"
             android:background="@drawable/my_profile_edit_profile_btn_background"
             android:text="@string/edit_profile"
-            android:textSize="10sp"
+            android:textSize="11sp"
             app:layout_constraintBottom_toBottomOf="@id/img_view_my_page_profile"
-            app:layout_constraintHeight_percent="0.03"
+            app:layout_constraintHeight_percent="0.033"
             app:layout_constraintLeft_toRightOf="@id/img_view_my_page_profile"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_my_page_status"
@@ -39,6 +39,7 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:background="@drawable/sign_up_user_type_selected"
+            android:gravity="center"
             android:text="@string/follow"
             android:textColor="@color/sign_up_user_type_text_color"
             android:textSize="11sp"
@@ -48,7 +49,7 @@
             app:layout_constraintLeft_toRightOf="@id/tv_my_page_nickname"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toTopOf="@id/tv_my_page_nickname"
-            app:layout_constraintWidth_percent="0.15" />
+            app:layout_constraintWidth_percent="0.16" />
 
         <ImageView
             android:id="@+id/img_view_my_page_profile"
@@ -100,7 +101,7 @@
             android:layout_marginTop="18dp"
             android:text="@string/follow"
             android:textColor="@color/black"
-            android:textSize="11sp"
+            android:textSize="12sp"
             android:textStyle="bold"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintLeft_toLeftOf="@id/img_view_my_page_profile"
@@ -112,7 +113,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@color/black"
-            android:textSize="11sp"
+            android:textSize="12sp"
             app:layout_constraintLeft_toLeftOf="@id/tv_follow_title"
             app:layout_constraintRight_toRightOf="@id/tv_follow_title"
             app:layout_constraintTop_toBottomOf="@id/tv_follow_title" />
@@ -124,7 +125,7 @@
             android:layout_marginTop="18dp"
             android:text="@string/follower"
             android:textColor="@color/black"
-            android:textSize="11sp"
+            android:textSize="12sp"
             android:textStyle="bold"
             app:layout_constraintHorizontal_bias="0.85"
             app:layout_constraintLeft_toLeftOf="@id/img_view_my_page_profile"
@@ -136,7 +137,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@color/black"
-            android:textSize="11sp"
+            android:textSize="12sp"
             app:layout_constraintLeft_toLeftOf="@id/tv_follower_title"
             app:layout_constraintRight_toRightOf="@id/tv_follower_title"
             app:layout_constraintTop_toBottomOf="@id/tv_follower_title" />
@@ -148,7 +149,7 @@
             android:layout_marginTop="18dp"
             android:text="@string/written_post"
             android:textColor="@color/black"
-            android:textSize="11sp"
+            android:textSize="12sp"
             android:textStyle="bold"
             app:layout_constraintHorizontal_bias="0.15"
             app:layout_constraintLeft_toLeftOf="@id/img_view_my_page_profile"
@@ -160,7 +161,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textColor="@color/black"
-            android:textSize="11sp"
+            android:textSize="12sp"
             app:layout_constraintLeft_toLeftOf="@id/tv_post_title"
             app:layout_constraintRight_toRightOf="@id/tv_post_title"
             app:layout_constraintTop_toBottomOf="@id/tv_post_title" />

--- a/Breaking/app/src/main/res/layout/fragment_post_tab.xml
+++ b/Breaking/app/src/main/res/layout/fragment_post_tab.xml
@@ -7,11 +7,19 @@
     android:orientation="vertical"
     tools:context=".fragment.user_tab.PostTabFragment">
 
+    <TextView
+        android:id="@+id/tv_empty_text"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="@string/no_written"
+        android:visibility="gone" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="7dp"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:padding="6dp">
 
         <TextView
             android:id="@+id/tv_option_all"
@@ -19,7 +27,7 @@
             android:layout_height="wrap_content"
             android:text="@string/entire_option"
             android:textColor="@color/breaking_bottom_clicked_color"
-            android:textSize="11sp"
+            android:textSize="11.5sp"
             android:textStyle="bold"
             app:layout_constraintHorizontal_bias="0.02"
             app:layout_constraintLeft_toLeftOf="parent"
@@ -32,7 +40,7 @@
             android:layout_height="wrap_content"
             android:text="@string/sold_option"
             android:textColor="@color/black"
-            android:textSize="11sp"
+            android:textSize="11.5sp"
             app:layout_constraintHorizontal_bias="0.17"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
@@ -44,20 +52,14 @@
             android:layout_height="wrap_content"
             android:text="@string/unsold_option"
             android:textColor="@color/black"
-            android:textSize="11sp"
+            android:textSize="11.5sp"
             app:layout_constraintHorizontal_bias="0.37"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-    <TextView
-        android:visibility="gone"
-        android:id="@+id/tv_empty_text"
-        android:gravity="center"
-        android:text="@string/no_written"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rcv_user_written"
         android:layout_width="match_parent"

--- a/Breaking/app/src/main/res/layout/fragment_purchased_tab.xml
+++ b/Breaking/app/src/main/res/layout/fragment_purchased_tab.xml
@@ -7,11 +7,19 @@
     android:orientation="vertical"
     tools:context=".fragment.user_tab.PurchasedTabFragment">
 
+    <TextView
+        android:id="@+id/tv_empty_text"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:text="@string/no_purchased"
+        android:visibility="gone" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:padding="7dp">
+        android:padding="6dp">
 
         <TextView
             android:id="@+id/tv_option_all"
@@ -19,7 +27,7 @@
             android:layout_height="wrap_content"
             android:text="@string/entire_option"
             android:textColor="@color/breaking_bottom_clicked_color"
-            android:textSize="11sp"
+            android:textSize="11.5sp"
             android:textStyle="bold"
             app:layout_constraintHorizontal_bias="0.02"
             app:layout_constraintLeft_toLeftOf="parent"
@@ -32,7 +40,7 @@
             android:layout_height="wrap_content"
             android:text="@string/sold_option"
             android:textColor="@color/black"
-            android:textSize="11sp"
+            android:textSize="11.5sp"
             app:layout_constraintHorizontal_bias="0.17"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
@@ -44,7 +52,7 @@
             android:layout_height="wrap_content"
             android:text="@string/unsold_option"
             android:textColor="@color/black"
-            android:textSize="11sp"
+            android:textSize="11.5sp"
             app:layout_constraintHorizontal_bias="0.37"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
@@ -52,13 +60,6 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <TextView
-        android:visibility="gone"
-        android:id="@+id/tv_empty_text"
-        android:gravity="center"
-        android:text="@string/no_purchased"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rcv_user_purchased"
         android:layout_width="match_parent"


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #110 

## 예상 리뷰 시간
3-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 현재 유저에 따라 유저페이지에 보여지는 탭이 달라지도록 수정했습니다. 
  - 현재 유저가 본인이라면 `작성 제보`, `구매 제보`, `북마크 제보` 탭 모두 보여지도록 했습니다. 
  - 현재 유저가 다른 유저라면 `작성 제보` 탭만 보이도록 했습니다.
- 피드 검색에서 검색 결과로 나온 피드 리스트에서 각 아이템 클릭 시 세부 조회 페이지로 이동하도록 연결했습니다. 
- `AndroidManifest.xml`에 중복되어 있는 속성을 제거했습니다.  
- 유저 페이지 일부 레이아웃 크기를 조정했습니다. 
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
- 마이 페이지의 경우
<img src="https://user-images.githubusercontent.com/54919474/189561228-8c8ef0c3-9c97-41c7-9088-794d4288f1fe.png" width="30%" height="30%" />

- 다른 유저 페이지의 경우
<img src="https://user-images.githubusercontent.com/54919474/189561235-92b2125e-fcaf-4ca2-9e93-418bda118324.png" width="30%" height="30%" />

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
x